### PR TITLE
feat: allow quality committee to manage all units

### DIFF
--- a/src/app/dashboard/indicators/page.tsx
+++ b/src/app/dashboard/indicators/page.tsx
@@ -18,6 +18,7 @@ import { PlusCircle } from "lucide-react";
 const centralRoles = [
   "Admin Sistem",
   "Direktur",
+  "PIC Mutu",
   "Sub. Komite Peningkatan Mutu",
   "Sub. Komite Keselamatan Pasien",
   "Sub. Komite Manajemen Risiko",

--- a/src/app/dashboard/overview/page.tsx
+++ b/src/app/dashboard/overview/page.tsx
@@ -39,6 +39,7 @@ import { id as IndonesianLocale } from "date-fns/locale"
 const centralRoles = [
   'Admin Sistem',
   'Direktur',
+  'PIC Mutu',
   'Sub. Komite Peningkatan Mutu',
   'Sub. Komite Keselamatan Pasien',
   'Sub. Komite Manajemen Risiko'

--- a/src/components/organisms/indicator-input-form.tsx
+++ b/src/components/organisms/indicator-input-form.tsx
@@ -22,6 +22,7 @@ import { useLogStore } from "@/store/log-store.tsx"
 const centralRoles = [
   'Admin Sistem',
   'Direktur',
+  'PIC Mutu',
   'Sub. Komite Peningkatan Mutu',
   'Sub. Komite Keselamatan Pasien',
   'Sub. Komite Manajemen Risiko'

--- a/src/components/organisms/indicator-report-table.tsx
+++ b/src/components/organisms/indicator-report-table.tsx
@@ -55,6 +55,11 @@ export function IndicatorReportTable({ indicators, onExport, onEdit, showCategor
       cell: ({ row }) => <div className="font-medium">{row.getValue("indicator")}</div>,
     },
     {
+      accessorKey: "unit",
+      header: "Unit",
+      cell: ({ row }) => <div>{row.getValue("unit")}</div>,
+    },
+    {
       accessorKey: "category",
       header: "Kategori",
       cell: ({ row }) => <Badge variant="outline">{row.getValue("category")}</Badge>,

--- a/src/components/organisms/indicator-report-table/actions-cell.tsx
+++ b/src/components/organisms/indicator-report-table/actions-cell.tsx
@@ -3,11 +3,15 @@
 
 import * as React from "react"
 import { Row } from "@tanstack/react-table"
-import { MoreHorizontal, Eye, Pencil } from "lucide-react"
+import { MoreHorizontal, Eye, Pencil, Trash2 } from "lucide-react"
 import { Button } from "@/components/ui/button"
-import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "@/components/ui/dropdown-menu"
-import { Indicator } from "@/store/indicator-store"
+import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger, DropdownMenuSeparator } from "@/components/ui/dropdown-menu"
+import { Indicator, useIndicatorStore } from "@/store/indicator-store"
 import { ReportDetailDialog } from "../report-detail-dialog"
+import { AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent, AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle, AlertDialogTrigger } from "../../ui/alert-dialog"
+import { useToast } from "@/hooks/use-toast"
+import { useLogStore } from "@/store/log-store.tsx"
+import { useUserStore } from "@/store/user-store.tsx"
 
 type ActionsCellProps = {
     row: Row<Indicator>,
@@ -17,6 +21,23 @@ type ActionsCellProps = {
 export function ActionsCell({ row, onEdit }: ActionsCellProps) {
     const indicator = row.original
     const [isDetailOpen, setIsDetailOpen] = React.useState(false);
+    const { removeIndicator } = useIndicatorStore.getState();
+    const { toast } = useToast();
+    const { addLog } = useLogStore();
+    const { currentUser } = useUserStore();
+
+    const handleDelete = () => {
+        removeIndicator(indicator.id);
+        addLog({
+            user: currentUser?.name || 'System',
+            action: 'DELETE_INDICATOR',
+            details: `Data capaian indikator "${indicator.indicator}" (${indicator.id}) dihapus.`,
+        });
+        toast({
+            title: 'Data Dihapus',
+            description: `Capaian indikator "${indicator.indicator}" telah dihapus.`,
+        });
+    };
 
     return (
         <>
@@ -37,6 +58,27 @@ export function ActionsCell({ row, onEdit }: ActionsCellProps) {
                             <Pencil className="mr-2 h-4 w-4" />
                             <span>Edit</span>
                         </DropdownMenuItem>
+                        <DropdownMenuSeparator />
+                        <AlertDialog>
+                            <AlertDialogTrigger asChild>
+                                <button className="relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 w-full text-destructive">
+                                    <Trash2 className="mr-2 h-4 w-4" />
+                                    Hapus
+                                </button>
+                            </AlertDialogTrigger>
+                            <AlertDialogContent>
+                                <AlertDialogHeader>
+                                    <AlertDialogTitle>Anda yakin?</AlertDialogTitle>
+                                    <AlertDialogDescription>
+                                        Aksi ini tidak dapat dibatalkan. Ini akan menghapus data capaian secara permanen.
+                                    </AlertDialogDescription>
+                                </AlertDialogHeader>
+                                <AlertDialogFooter>
+                                    <AlertDialogCancel>Batal</AlertDialogCancel>
+                                    <AlertDialogAction onClick={handleDelete} className="bg-destructive hover:bg-destructive/90">Hapus</AlertDialogAction>
+                                </AlertDialogFooter>
+                            </AlertDialogContent>
+                        </AlertDialog>
                     </DropdownMenuContent>
                 </DropdownMenu>
             </div>

--- a/src/components/organisms/indicator-report.tsx
+++ b/src/components/organisms/indicator-report.tsx
@@ -19,6 +19,7 @@ import { AnalysisTable } from "./analysis-table"
 const centralRoles = [
   'Admin Sistem',
   'Direktur',
+  'PIC Mutu',
   'Sub. Komite Peningkatan Mutu',
   'Sub. Komite Keselamatan Pasien',
   'Sub. Komite Manajemen Risiko'

--- a/src/components/organisms/indicator-submission-form.tsx
+++ b/src/components/organisms/indicator-submission-form.tsx
@@ -147,7 +147,10 @@ export function IndicatorSubmissionForm({ setOpen, indicator }: IndicatorSubmiss
   React.useEffect(() => {
     // If user is not an admin and category is not IMPU, force their unit
     if (!userIsAdmin && selectedCategory !== 'IMPU') {
-        form.setValue('unit', currentUser?.unit || '');
+        const unitValue = currentUser?.unit || '';
+        if (form.getValues('unit') !== unitValue) {
+            form.setValue('unit', unitValue);
+        }
     }
   }, [selectedCategory, userIsAdmin, currentUser?.unit, form]);
 

--- a/src/components/organisms/indicator-submission-form.tsx
+++ b/src/components/organisms/indicator-submission-form.tsx
@@ -75,6 +75,7 @@ const unitOptions = HOSPITAL_UNITS.map(unit => ({ value: unit, label: unit }));
 const centralRoles = [
   'Admin Sistem',
   'Direktur',
+  'PIC Mutu',
   'Sub. Komite Peningkatan Mutu',
   'Sub. Komite Keselamatan Pasien',
   'Sub. Komite Manajemen Risiko'

--- a/src/components/templates/indicator-dashboard-template.tsx
+++ b/src/components/templates/indicator-dashboard-template.tsx
@@ -22,7 +22,7 @@ type IndicatorDashboardTemplateProps = {
 export function IndicatorDashboardTemplate({ category, pageTitle }: IndicatorDashboardTemplateProps) {
   const { indicators } = useIndicatorStore()
   const { currentUser } = useUserStore()
-  const userIsCentral = currentUser && ["Admin Sistem", "Direktur", "Sub. Komite Peningkatan Mutu", "Sub. Komite Keselamatan Pasien", "Sub. Komite Manajemen Risiko"].includes(currentUser.role)
+  const userIsCentral = currentUser && ["Admin Sistem", "Direktur", "PIC Mutu", "Sub. Komite Peningkatan Mutu", "Sub. Komite Keselamatan Pasien", "Sub. Komite Manajemen Risiko"].includes(currentUser.role)
 
   const categoryIndicators = React.useMemo(() => {
     const filteredByCategory = indicators.filter(i => i.category === category)

--- a/src/store/indicator-store.ts
+++ b/src/store/indicator-store.ts
@@ -44,6 +44,7 @@ type IndicatorState = {
   submittedIndicators: SubmittedIndicator[]
   addIndicator: (indicator: Omit<Indicator, 'id' |'ratio' | 'status'>) => string
   updateIndicator: (id: string, data: Partial<Omit<Indicator, 'id' |'ratio' | 'status'>>) => void
+  removeIndicator: (id: string) => void
   submitIndicator: (
     indicator: Omit<SubmittedIndicator, 'id' | 'status' | 'submissionDate'>,
     sendNotificationCallback?: () => void
@@ -90,6 +91,10 @@ export const useIndicatorStore = create<IndicatorState>((set, get) => ({
         }
         return indicator
       }),
+    })),
+  removeIndicator: (id) =>
+    set((state) => ({
+      indicators: state.indicators.filter((indicator) => indicator.id !== id),
     })),
   submitIndicator: (
     indicator: Omit<SubmittedIndicator, 'id' | 'status' | 'submissionDate'>,


### PR DESCRIPTION
## Summary
- allow PIC Mutu and admins to choose any unit and view all unit data
- show unit column and enable deleting indicator achievements
- support removing indicator records in the store

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_68a3c840fed88325b2f7f92304285d90