### PR TITLE
Fix central role detection to allow admin unit selection

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -21,7 +21,12 @@ import Image from "next/image"
 import favicon from "@/app/favicon.ico"
 import { login } from "@/lib/actions/auth"
 import { useLogStore } from "@/store/log-store.tsx"
-import type { User } from "@prisma/client"
+import type { User, UserRole as DbUserRole } from "@prisma/client"
+import {
+  useUserStore,
+  type UserRole,
+  type User as StoreUser,
+} from "@/store/user-store.tsx"
 
 export default function LoginPage() {
   const router = useRouter()
@@ -29,7 +34,19 @@ export default function LoginPage() {
   const [showPassword, setShowPassword] = useState(false)
   const [isLoading, setIsLoading] = useState(false)
   const { addLog } = useLogStore()
+  const { setCurrentUser } = useUserStore()
   const [demoUsers, setDemoUsers] = useState<User[]>([])
+
+  const roleMap: Record<DbUserRole, UserRole> = {
+    ADMIN_SISTEM: "Admin Sistem",
+    PIC_MUTU: "PIC Mutu",
+    PJ_RUANGAN: "PJ Ruangan",
+    KEPALA_UNIT_INSTALASI: "Kepala Unit/Instalasi",
+    DIREKTUR: "Direktur",
+    SUB_KOMITE_PENINGKATAN_MUTU: "Sub. Komite Peningkatan Mutu",
+    SUB_KOMITE_KESELAMATAN_PASIEN: "Sub. Komite Keselamatan Pasien",
+    SUB_KOMITE_MANAJEMEN_RISIKO: "Sub. Komite Manajemen Risiko",
+  }
 
   React.useEffect(() => {
     // In a real app, you wouldn't fetch demo users like this.
@@ -58,6 +75,16 @@ export default function LoginPage() {
       if (!user) {
         throw new Error("User not found after login.")
       }
+
+      const storeUser: StoreUser = {
+        id: user.id,
+        name: user.name,
+        email: user.email,
+        role: roleMap[user.role as DbUserRole],
+        unit: user.unit ?? undefined,
+      }
+
+      setCurrentUser(storeUser)
       addLog({
         user: user.name,
         action: "LOGIN_SUCCESS",

--- a/src/store/central-roles.ts
+++ b/src/store/central-roles.ts
@@ -1,7 +1,11 @@
+// Roles that are considered "central" and therefore have access to
+// organisation-wide functionality.  These string values must match the
+// `UserRole` definitions in `user-store.tsx` so that role comparisons work
+// correctly throughout the application.
 export const centralRoles = [
-    "ADMIN_SISTEM",
-    "DIREKTUR",
-    'SUB_KOMITE_KESELAMATAN_PASIEN',
-    'SUB_KOMITE_PENINGKATAN_MUTU',
-    'SUB_KOMITE_MANAJEMEN_RISIKO'
+  "Admin Sistem",
+  "Direktur",
+  "Sub. Komite Keselamatan Pasien",
+  "Sub. Komite Peningkatan Mutu",
+  "Sub. Komite Manajemen Risiko",
 ];


### PR DESCRIPTION
## Summary
- align central role names with user role strings so central users (e.g., Admin Sistem) are recognized
- add documentation comment to central role list

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run typecheck` *(fails: 32 errors)*

------
https://chatgpt.com/codex/tasks/task_b_68a3ff84c9548325b642c56372a05524