### PR TITLE
fix: allow bar chart view

### DIFF
--- a/src/components/organisms/indicator-chart-card.tsx
+++ b/src/components/organisms/indicator-chart-card.tsx
@@ -31,6 +31,7 @@ type IndicatorChartCardProps = {
   description: string
   filterType: string
   selectedIndicator: string
+  chartType: 'line' | 'bar'
 }
 
 export function IndicatorChartCard({
@@ -38,8 +39,8 @@ export function IndicatorChartCard({
   description,
   filterType,
   selectedIndicator,
+  chartType,
 }: IndicatorChartCardProps) {
-  const [chartType, setChartType] = React.useState<"line" | "bar">("line")
 
   const ChartTooltipContent = (props: any) => {
     const { active, payload } = props

--- a/src/components/organisms/indicator-filter-card.tsx
+++ b/src/components/organisms/indicator-filter-card.tsx
@@ -41,6 +41,8 @@ type IndicatorFilterCardProps = {
   setFilterType: (type: FilterType) => void;
   selectedDate: Date;
   setSelectedDate: (date: Date) => void;
+  chartType: 'line' | 'bar';
+  setChartType: (type: 'line' | 'bar') => void;
 }
 
 export function IndicatorFilterCard({
@@ -54,9 +56,9 @@ export function IndicatorFilterCard({
   setFilterType,
   selectedDate,
   setSelectedDate,
+  chartType,
+  setChartType,
 }: IndicatorFilterCardProps) {
-  
-  const [chartType, setChartType] = React.useState<'line' | 'bar'>('line');
 
   const renderFilterInput = () => {
     // Component logic from the original page

--- a/src/components/templates/indicator-dashboard-template.tsx
+++ b/src/components/templates/indicator-dashboard-template.tsx
@@ -24,7 +24,7 @@ type IndicatorDashboardTemplateProps = {
 export function IndicatorDashboardTemplate({ category, pageTitle }: IndicatorDashboardTemplateProps) {
   const { indicators } = useIndicatorStore()
   const { currentUser } = useUserStore()
-  const userIsCentral = currentUser && centralRoles.includes(currentUser.role)
+  const userIsCentral = currentUser ? centralRoles.includes(currentUser.role) : false
 
   const categoryIndicators = React.useMemo(() => {
     return indicators.filter(i => i.category === category)
@@ -35,6 +35,7 @@ export function IndicatorDashboardTemplate({ category, pageTitle }: IndicatorDas
   const [selectedIndicator, setSelectedIndicator] = React.useState<string>("Semua Indikator")
   const [filterType, setFilterType] = React.useState<FilterType>("this_month")
   const [selectedDate, setSelectedDate] = React.useState<Date>(new Date())
+  const [chartType, setChartType] = React.useState<"line" | "bar">("line")
 
   // If user is not central, force their unit
   React.useEffect(() => {
@@ -92,6 +93,8 @@ export function IndicatorDashboardTemplate({ category, pageTitle }: IndicatorDas
           setFilterType={setFilterType}
           selectedDate={selectedDate}
           setSelectedDate={setSelectedDate}
+          chartType={chartType}
+          setChartType={setChartType}
         />
 
         <IndicatorChartCard
@@ -99,6 +102,7 @@ export function IndicatorDashboardTemplate({ category, pageTitle }: IndicatorDas
           description={getChartDescription()}
           filterType={filterType}
           selectedIndicator={selectedIndicator}
+          chartType={chartType}
         />
 
         <IndicatorReport


### PR DESCRIPTION
## Summary
- share chart type state across filter and chart components
- toggle line and bar chart displays

## Testing
- `npm run lint`
- `npm run typecheck` *(fails: filterFns missing and other unrelated errors)*

------
https://chatgpt.com/codex/tasks/task_b_68a40766ad58832599506ac2583f88bb