### PR TITLE
Add delete option for incident reports

### DIFF
--- a/src/components/organisms/incident-table/actions-cell.tsx
+++ b/src/components/organisms/incident-table/actions-cell.tsx
@@ -3,7 +3,7 @@
 
 import * as React from "react"
 import { Row } from "@tanstack/react-table"
-import { MoreHorizontal, Eye, Pencil, CheckCircle, ShieldQuestion } from "lucide-react"
+import { MoreHorizontal, Eye, Pencil, CheckCircle, ShieldQuestion, Trash2 } from "lucide-react"
 
 import { Button } from "@/components/ui/button"
 import {
@@ -21,6 +21,8 @@ import { Incident, IncidentStatus, useIncidentStore } from "@/store/incident-sto
 import { IncidentReportDialog } from "../incident-report-dialog"
 import { useUserStore } from "@/store/user-store.tsx"
 import { useLogStore } from "@/store/log-store.tsx"
+import { AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent, AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle, AlertDialogTrigger } from "@/components/ui/alert-dialog"
+import { useToast } from "@/hooks/use-toast"
 
 type ActionsCellProps = {
   row: Row<Incident>;
@@ -31,7 +33,8 @@ export function ActionsCell({ row, onViewDetails }: ActionsCellProps) {
   const incident = row.original
   const { currentUser } = useUserStore();
   const { addLog } = useLogStore();
-  const { updateIncidentStatus } = useIncidentStore()
+  const { updateIncidentStatus, removeIncident } = useIncidentStore()
+  const { toast } = useToast();
   const [isEditDialogOpen, setIsEditDialogOpen] = React.useState(false)
 
   const canChangeStatus = currentUser?.role === 'Admin Sistem' || currentUser?.role === 'Sub. Komite Keselamatan Pasien';
@@ -42,6 +45,19 @@ export function ActionsCell({ row, onViewDetails }: ActionsCellProps) {
       user: currentUser?.name || 'System',
       action: 'UPDATE_INCIDENT',
       details: `Status insiden ${incident.id} diubah menjadi ${status}.`
+    })
+  }
+
+  const handleDelete = () => {
+    removeIncident(incident.id)
+    addLog({
+      user: currentUser?.name || 'System',
+      action: 'DELETE_INCIDENT',
+      details: `Laporan insiden ${incident.id} dihapus.`,
+    })
+    toast({
+      title: "Laporan Dihapus",
+      description: `Laporan insiden ${incident.id} telah berhasil dihapus.`,
     })
   }
 
@@ -84,6 +100,27 @@ export function ActionsCell({ row, onViewDetails }: ActionsCellProps) {
               </DropdownMenuSub>
             </>
           )}
+          <DropdownMenuSeparator />
+          <AlertDialog>
+            <AlertDialogTrigger asChild>
+              <button className="relative flex cursor-pointer select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 w-full text-destructive hover:bg-destructive/10">
+                <Trash2 className="mr-2 h-4 w-4" />
+                <span>Hapus</span>
+              </button>
+            </AlertDialogTrigger>
+            <AlertDialogContent>
+              <AlertDialogHeader>
+                <AlertDialogTitle>Anda yakin?</AlertDialogTitle>
+                <AlertDialogDescription>
+                  Aksi ini tidak dapat dibatalkan. Ini akan menghapus laporan insiden secara permanen.
+                </AlertDialogDescription>
+              </AlertDialogHeader>
+              <AlertDialogFooter>
+                <AlertDialogCancel>Batal</AlertDialogCancel>
+                <AlertDialogAction onClick={handleDelete} className="bg-destructive hover:bg-destructive/90">Hapus</AlertDialogAction>
+              </AlertDialogFooter>
+            </AlertDialogContent>
+          </AlertDialog>
         </DropdownMenuContent>
       </DropdownMenu>
 

--- a/src/store/incident-store.ts
+++ b/src/store/incident-store.ts
@@ -53,6 +53,7 @@ type IncidentState = {
   addIncident: (incident: Omit<Incident, 'id' | 'date' | 'status'>) => string
   updateIncident: (id: string, incident: Partial<Omit<Incident, 'id' | 'date' | 'status'>>) => void
   updateIncidentStatus: (id: string, status: IncidentStatus) => void;
+  removeIncident: (id: string) => void;
 }
 
 const initialIncidents: Incident[] = [];
@@ -85,8 +86,11 @@ export const useIncidentStore = create<IncidentState>((set, get) => ({
       })
   })),
   updateIncidentStatus: (id, status) => set(state => ({
-      incidents: state.incidents.map(inc => 
+      incidents: state.incidents.map(inc =>
           inc.id === id ? { ...inc, status } : inc
       )
+  })),
+  removeIncident: (id) => set(state => ({
+      incidents: state.incidents.filter(inc => inc.id !== id)
   }))
 }))

--- a/src/store/log-store.tsx
+++ b/src/store/log-store.tsx
@@ -19,6 +19,7 @@ type LogAction =
  | 'DELETE_SUBMITTED_INDICATOR'
  | 'ADD_INCIDENT'
  | 'UPDATE_INCIDENT'
+ | 'DELETE_INCIDENT'
 
 
 export type SystemLog = {


### PR DESCRIPTION
## Summary
- enable removing incident reports from incident store
- log incident deletions and surface delete action in table

## Testing
- `npm run lint`
- `npm run typecheck` *(fails: Property 'filterFns' is missing...)*

------
https://chatgpt.com/codex/tasks/task_b_68a40ce6861483258f4411d8188b0563