### PR TITLE
feat: add demo nestjs backend

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,1 @@
+backend

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -1,0 +1,17 @@
+import { Module } from '@nestjs/common';
+import { UsersModule } from './users/users.module';
+import { IndicatorSubmissionsModule } from './indicator-submissions/indicator-submissions.module';
+import { IndicatorsModule } from './indicators/indicators.module';
+import { IncidentsModule } from './incidents/incidents.module';
+import { RisksModule } from './risks/risks.module';
+
+@Module({
+  imports: [
+    UsersModule,
+    IndicatorSubmissionsModule,
+    IndicatorsModule,
+    IncidentsModule,
+    RisksModule,
+  ],
+})
+export class AppModule {}

--- a/backend/src/incidents/incidents.controller.ts
+++ b/backend/src/incidents/incidents.controller.ts
@@ -1,0 +1,28 @@
+import { Controller, Get, Post, Put, Delete, Body, Param } from '@nestjs/common';
+import { IncidentsService } from './incidents.service';
+import { CreateIncidentDto, UpdateIncidentDto } from './incidents.types';
+
+@Controller('incidents')
+export class IncidentsController {
+  constructor(private readonly service: IncidentsService) {}
+
+  @Get()
+  findAll() {
+    return this.service.findAll();
+  }
+
+  @Post()
+  create(@Body() dto: CreateIncidentDto) {
+    return this.service.create(dto);
+  }
+
+  @Put(':id')
+  update(@Param('id') id: string, @Body() dto: UpdateIncidentDto) {
+    return this.service.update(id, dto);
+  }
+
+  @Delete(':id')
+  remove(@Param('id') id: string) {
+    return this.service.remove(id);
+  }
+}

--- a/backend/src/incidents/incidents.module.ts
+++ b/backend/src/incidents/incidents.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { IncidentsService } from './incidents.service';
+import { IncidentsController } from './incidents.controller';
+
+@Module({
+  controllers: [IncidentsController],
+  providers: [IncidentsService],
+})
+export class IncidentsModule {}

--- a/backend/src/incidents/incidents.service.ts
+++ b/backend/src/incidents/incidents.service.ts
@@ -1,0 +1,30 @@
+import { Injectable } from '@nestjs/common';
+import { Incident, CreateIncidentDto, UpdateIncidentDto } from './incidents.types';
+
+@Injectable()
+export class IncidentsService {
+  private incidents: Incident[] = [];
+
+  create(dto: CreateIncidentDto): Incident {
+    const incident: Incident = { id: Date.now().toString(), ...dto };
+    this.incidents.push(incident);
+    return incident;
+  }
+
+  findAll(): Incident[] {
+    return this.incidents;
+  }
+
+  update(id: string, dto: UpdateIncidentDto): Incident {
+    const incident = this.incidents.find((i) => i.id === id);
+    if (!incident) {
+      throw new Error('Incident not found');
+    }
+    Object.assign(incident, dto);
+    return incident;
+  }
+
+  remove(id: string): void {
+    this.incidents = this.incidents.filter((i) => i.id !== id);
+  }
+}

--- a/backend/src/incidents/incidents.types.ts
+++ b/backend/src/incidents/incidents.types.ts
@@ -1,0 +1,27 @@
+export interface Incident {
+  id: string;
+  date: string;
+  status: string;
+  type: string;
+  severity: string;
+  patientName: string;
+  chronology: string;
+}
+
+export interface CreateIncidentDto {
+  date: string;
+  status: string;
+  type: string;
+  severity: string;
+  patientName: string;
+  chronology: string;
+}
+
+export interface UpdateIncidentDto {
+  date?: string;
+  status?: string;
+  type?: string;
+  severity?: string;
+  patientName?: string;
+  chronology?: string;
+}

--- a/backend/src/indicator-submissions/indicator-submissions.controller.ts
+++ b/backend/src/indicator-submissions/indicator-submissions.controller.ts
@@ -1,0 +1,35 @@
+import { Controller, Get, Post, Put, Body, Param, Query } from '@nestjs/common';
+import { IndicatorSubmissionsService } from './indicator-submissions.service';
+import {
+  CreateIndicatorSubmissionDto,
+  UpdateIndicatorSubmissionDto,
+  UpdateSubmissionStatusDto,
+} from './indicator-submissions.types';
+
+@Controller('indicatorSubmissions')
+export class IndicatorSubmissionsController {
+  constructor(private readonly service: IndicatorSubmissionsService) {}
+
+  @Get()
+  findAll(@Query('unit') unit?: string) {
+    return this.service.findAll(unit);
+  }
+
+  @Post()
+  create(@Body() dto: CreateIndicatorSubmissionDto) {
+    return this.service.create(dto);
+  }
+
+  @Put(':id')
+  update(@Param('id') id: string, @Body() dto: UpdateIndicatorSubmissionDto) {
+    return this.service.update(id, dto);
+  }
+
+  @Put(':id/status')
+  updateStatus(
+    @Param('id') id: string,
+    @Body() dto: UpdateSubmissionStatusDto,
+  ) {
+    return this.service.updateStatus(id, dto);
+  }
+}

--- a/backend/src/indicator-submissions/indicator-submissions.module.ts
+++ b/backend/src/indicator-submissions/indicator-submissions.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { IndicatorSubmissionsService } from './indicator-submissions.service';
+import { IndicatorSubmissionsController } from './indicator-submissions.controller';
+
+@Module({
+  controllers: [IndicatorSubmissionsController],
+  providers: [IndicatorSubmissionsService],
+})
+export class IndicatorSubmissionsModule {}

--- a/backend/src/indicator-submissions/indicator-submissions.service.ts
+++ b/backend/src/indicator-submissions/indicator-submissions.service.ts
@@ -1,0 +1,52 @@
+import { Injectable } from '@nestjs/common';
+import {
+  IndicatorSubmission,
+  CreateIndicatorSubmissionDto,
+  UpdateIndicatorSubmissionDto,
+  UpdateSubmissionStatusDto,
+} from './indicator-submissions.types';
+
+@Injectable()
+export class IndicatorSubmissionsService {
+  private submissions: IndicatorSubmission[] = [];
+
+  create(dto: CreateIndicatorSubmissionDto): IndicatorSubmission {
+    const submission: IndicatorSubmission = {
+      id: Date.now().toString(),
+      status: 'Pending',
+      submissionDate: new Date().toISOString(),
+      ...dto,
+    };
+    this.submissions.push(submission);
+    return submission;
+  }
+
+  findAll(unit?: string): IndicatorSubmission[] {
+    if (unit) {
+      return this.submissions.filter((s) => s.unit === unit);
+    }
+    return this.submissions;
+  }
+
+  update(id: string, dto: UpdateIndicatorSubmissionDto): IndicatorSubmission {
+    const submission = this.submissions.find((s) => s.id === id);
+    if (!submission) {
+      throw new Error('Submission not found');
+    }
+    Object.assign(submission, dto);
+    return submission;
+  }
+
+  updateStatus(
+    id: string,
+    dto: UpdateSubmissionStatusDto,
+  ): IndicatorSubmission {
+    const submission = this.submissions.find((s) => s.id === id);
+    if (!submission) {
+      throw new Error('Submission not found');
+    }
+    submission.status = dto.status;
+    submission.rejectionReason = dto.rejectionReason;
+    return submission;
+  }
+}

--- a/backend/src/indicator-submissions/indicator-submissions.types.ts
+++ b/backend/src/indicator-submissions/indicator-submissions.types.ts
@@ -1,0 +1,40 @@
+export interface IndicatorSubmission {
+  id: string;
+  name: string;
+  category: string;
+  description: string;
+  unit: string;
+  frequency: string;
+  status: string;
+  standardUnit: string;
+  standard: number;
+  submissionDate: string;
+  submittedById: string;
+  rejectionReason?: string;
+}
+
+export interface CreateIndicatorSubmissionDto {
+  name: string;
+  category: string;
+  description: string;
+  unit: string;
+  frequency: string;
+  standardUnit: string;
+  standard: number;
+  submittedById: string;
+}
+
+export interface UpdateIndicatorSubmissionDto {
+  name?: string;
+  category?: string;
+  description?: string;
+  unit?: string;
+  frequency?: string;
+  standardUnit?: string;
+  standard?: number;
+}
+
+export interface UpdateSubmissionStatusDto {
+  status: string;
+  rejectionReason?: string;
+}

--- a/backend/src/indicators/indicators.controller.ts
+++ b/backend/src/indicators/indicators.controller.ts
@@ -1,0 +1,32 @@
+import { Controller, Get, Post, Put, Delete, Body, Param, Query } from '@nestjs/common';
+import { IndicatorsService } from './indicators.service';
+import { CreateIndicatorDto, UpdateIndicatorDto } from './indicators.types';
+
+@Controller('indicators')
+export class IndicatorsController {
+  constructor(private readonly service: IndicatorsService) {}
+
+  @Get()
+  findAll(
+    @Query('category') category?: string,
+    @Query('start') start?: string,
+    @Query('end') end?: string,
+  ) {
+    return this.service.findAll(category, start, end);
+  }
+
+  @Post()
+  create(@Body() dto: CreateIndicatorDto) {
+    return this.service.create(dto);
+  }
+
+  @Put(':id')
+  update(@Param('id') id: string, @Body() dto: UpdateIndicatorDto) {
+    return this.service.update(id, dto);
+  }
+
+  @Delete(':id')
+  remove(@Param('id') id: string) {
+    return this.service.remove(id);
+  }
+}

--- a/backend/src/indicators/indicators.module.ts
+++ b/backend/src/indicators/indicators.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { IndicatorsService } from './indicators.service';
+import { IndicatorsController } from './indicators.controller';
+
+@Module({
+  controllers: [IndicatorsController],
+  providers: [IndicatorsService],
+})
+export class IndicatorsModule {}

--- a/backend/src/indicators/indicators.service.ts
+++ b/backend/src/indicators/indicators.service.ts
@@ -1,0 +1,36 @@
+import { Injectable } from '@nestjs/common';
+import { Indicator, CreateIndicatorDto, UpdateIndicatorDto } from './indicators.types';
+
+@Injectable()
+export class IndicatorsService {
+  private indicators: Indicator[] = [];
+
+  create(dto: CreateIndicatorDto): Indicator {
+    const indicator: Indicator = { id: Date.now().toString(), ...dto };
+    this.indicators.push(indicator);
+    return indicator;
+  }
+
+  findAll(category?: string, start?: string, end?: string): Indicator[] {
+    return this.indicators.filter((i) => {
+      const withinCategory = category ? i.submissionId === category : true;
+      const period = new Date(i.period).getTime();
+      const afterStart = start ? period >= new Date(start).getTime() : true;
+      const beforeEnd = end ? period <= new Date(end).getTime() : true;
+      return withinCategory && afterStart && beforeEnd;
+    });
+  }
+
+  update(id: string, dto: UpdateIndicatorDto): Indicator {
+    const indicator = this.indicators.find((i) => i.id === id);
+    if (!indicator) {
+      throw new Error('Indicator not found');
+    }
+    Object.assign(indicator, dto);
+    return indicator;
+  }
+
+  remove(id: string): void {
+    this.indicators = this.indicators.filter((i) => i.id !== id);
+  }
+}

--- a/backend/src/indicators/indicators.types.ts
+++ b/backend/src/indicators/indicators.types.ts
@@ -1,0 +1,26 @@
+export interface Indicator {
+  id: string;
+  submissionId: string;
+  period: string;
+  numerator: number;
+  denominator: number;
+  analysisNotes?: string;
+  followUpPlan?: string;
+}
+
+export interface CreateIndicatorDto {
+  submissionId: string;
+  period: string;
+  numerator: number;
+  denominator: number;
+  analysisNotes?: string;
+  followUpPlan?: string;
+}
+
+export interface UpdateIndicatorDto {
+  period?: string;
+  numerator?: number;
+  denominator?: number;
+  analysisNotes?: string;
+  followUpPlan?: string;
+}

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -1,0 +1,9 @@
+import 'reflect-metadata';
+import { NestFactory } from '@nestjs/core';
+import { AppModule } from './app.module';
+
+async function bootstrap() {
+  const app = await NestFactory.create(AppModule);
+  await app.listen(3001);
+}
+bootstrap();

--- a/backend/src/risks/risks.controller.ts
+++ b/backend/src/risks/risks.controller.ts
@@ -1,0 +1,28 @@
+import { Controller, Get, Post, Put, Delete, Body, Param } from '@nestjs/common';
+import { RisksService } from './risks.service';
+import { CreateRiskDto, UpdateRiskDto } from './risks.types';
+
+@Controller('risks')
+export class RisksController {
+  constructor(private readonly service: RisksService) {}
+
+  @Get()
+  findAll() {
+    return this.service.findAll();
+  }
+
+  @Post()
+  create(@Body() dto: CreateRiskDto) {
+    return this.service.create(dto);
+  }
+
+  @Put(':id')
+  update(@Param('id') id: string, @Body() dto: UpdateRiskDto) {
+    return this.service.update(id, dto);
+  }
+
+  @Delete(':id')
+  remove(@Param('id') id: string) {
+    return this.service.remove(id);
+  }
+}

--- a/backend/src/risks/risks.module.ts
+++ b/backend/src/risks/risks.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { RisksService } from './risks.service';
+import { RisksController } from './risks.controller';
+
+@Module({
+  controllers: [RisksController],
+  providers: [RisksService],
+})
+export class RisksModule {}

--- a/backend/src/risks/risks.service.ts
+++ b/backend/src/risks/risks.service.ts
@@ -1,0 +1,30 @@
+import { Injectable } from '@nestjs/common';
+import { Risk, CreateRiskDto, UpdateRiskDto } from './risks.types';
+
+@Injectable()
+export class RisksService {
+  private risks: Risk[] = [];
+
+  create(dto: CreateRiskDto): Risk {
+    const risk: Risk = { id: Date.now().toString(), ...dto };
+    this.risks.push(risk);
+    return risk;
+  }
+
+  findAll(): Risk[] {
+    return this.risks;
+  }
+
+  update(id: string, dto: UpdateRiskDto): Risk {
+    const risk = this.risks.find((r) => r.id === id);
+    if (!risk) {
+      throw new Error('Risk not found');
+    }
+    Object.assign(risk, dto);
+    return risk;
+  }
+
+  remove(id: string): void {
+    this.risks = this.risks.filter((r) => r.id !== id);
+  }
+}

--- a/backend/src/risks/risks.types.ts
+++ b/backend/src/risks/risks.types.ts
@@ -1,0 +1,30 @@
+export interface Risk {
+  id: string;
+  unit: string;
+  source: string;
+  description: string;
+  cause: string;
+  consequence: number;
+  likelihood: number;
+  status: string;
+}
+
+export interface CreateRiskDto {
+  unit: string;
+  source: string;
+  description: string;
+  cause: string;
+  consequence: number;
+  likelihood: number;
+  status: string;
+}
+
+export interface UpdateRiskDto {
+  unit?: string;
+  source?: string;
+  description?: string;
+  cause?: string;
+  consequence?: number;
+  likelihood?: number;
+  status?: string;
+}

--- a/backend/src/users/users.controller.ts
+++ b/backend/src/users/users.controller.ts
@@ -1,0 +1,33 @@
+import { Controller, Get, Post, Put, Delete, Body, Param } from '@nestjs/common';
+import { UsersService } from './users.service';
+import { CreateUserDto, UpdateUserDto, LoginDto } from './users.types';
+
+@Controller('users')
+export class UsersController {
+  constructor(private readonly usersService: UsersService) {}
+
+  @Post('login')
+  login(@Body() dto: LoginDto) {
+    return this.usersService.login(dto);
+  }
+
+  @Get()
+  findAll() {
+    return this.usersService.findAll();
+  }
+
+  @Post()
+  create(@Body() dto: CreateUserDto) {
+    return this.usersService.create(dto);
+  }
+
+  @Put(':id')
+  update(@Param('id') id: string, @Body() dto: UpdateUserDto) {
+    return this.usersService.update(id, dto);
+  }
+
+  @Delete(':id')
+  remove(@Param('id') id: string) {
+    return this.usersService.remove(id);
+  }
+}

--- a/backend/src/users/users.module.ts
+++ b/backend/src/users/users.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { UsersService } from './users.service';
+import { UsersController } from './users.controller';
+
+@Module({
+  controllers: [UsersController],
+  providers: [UsersService],
+})
+export class UsersModule {}

--- a/backend/src/users/users.service.ts
+++ b/backend/src/users/users.service.ts
@@ -1,0 +1,36 @@
+import { Injectable } from '@nestjs/common';
+import { CreateUserDto, UpdateUserDto, LoginDto, User } from './users.types';
+
+@Injectable()
+export class UsersService {
+  private users: User[] = [];
+
+  create(dto: CreateUserDto): User {
+    const user: User = { id: Date.now().toString(), ...dto };
+    this.users.push(user);
+    return user;
+  }
+
+  findAll(): User[] {
+    return this.users;
+  }
+
+  update(id: string, dto: UpdateUserDto): User {
+    const user = this.users.find((u) => u.id === id);
+    if (!user) {
+      throw new Error('User not found');
+    }
+    Object.assign(user, dto);
+    return user;
+  }
+
+  remove(id: string): void {
+    this.users = this.users.filter((u) => u.id !== id);
+  }
+
+  login(dto: LoginDto): User | undefined {
+    return this.users.find(
+      (u) => u.email === dto.email && u.password === dto.password,
+    );
+  }
+}

--- a/backend/src/users/users.types.ts
+++ b/backend/src/users/users.types.ts
@@ -1,0 +1,29 @@
+export interface User {
+  id: string;
+  name: string;
+  email: string;
+  password: string;
+  role: string;
+  unit?: string;
+}
+
+export interface CreateUserDto {
+  name: string;
+  email: string;
+  password: string;
+  role: string;
+  unit?: string;
+}
+
+export interface UpdateUserDto {
+  name?: string;
+  email?: string;
+  password?: string;
+  role?: string;
+  unit?: string;
+}
+
+export interface LoginDto {
+  email: string;
+  password: string;
+}

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "target": "es2017",
+    "experimentalDecorators": true,
+    "emitDecoratorMetadata": true,
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "outDir": "dist"
+  },
+  "include": ["src/**/*"]
+}

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "start": "next start",
     "lint": "next lint",
     "typecheck": "tsc --noEmit",
-    "format": "prettier --write ."
+    "format": "prettier --write .",
+    "backend": "ts-node -P backend/tsconfig.json backend/src/main.ts"
   },
   "dependencies": {
     "@genkit-ai/googleai": "^1.14.1",
@@ -57,7 +58,12 @@
     "tailwind-merge": "^3.0.1",
     "tailwindcss-animate": "^1.0.7",
     "zod": "^3.24.2",
-    "zustand": "^4.5.4"
+    "zustand": "^4.5.4",
+    "@nestjs/common": "^10.0.0",
+    "@nestjs/core": "^10.0.0",
+    "@nestjs/platform-express": "^10.0.0",
+    "reflect-metadata": "^0.2.0",
+    "rxjs": "^7.8.1"
   },
   "devDependencies": {
     "@types/node": "^20",
@@ -71,6 +77,7 @@
     "prettier-plugin-tailwindcss": "^0.6.5",
     "prisma": "^5.17.0",
     "tailwindcss": "^3.4.1",
-    "typescript": "^5"
+    "typescript": "^5",
+    "ts-node": "^10.9.2"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -23,5 +23,5 @@
     }
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules", "backend"]
 }


### PR DESCRIPTION
## Summary
- set up NestJS backend scaffold with modules for users, indicator submissions, indicators, incidents, and risks
- wire up in-memory services and REST controllers for core SIRATU resources
- add backend script, tsconfig and dependency placeholders

## Testing
- `npm install` (fails: 403 Forbidden)
- `npm run lint` (fails: react/no-unescaped-entities, parsing error)
- `npm run typecheck` (fails: TS1005 in src/store/user-store.ts)


------
https://chatgpt.com/codex/tasks/task_b_68a4338882448325875dd75714e6fb5e