### PR TITLE
feat: add survey dashboard and form

### DIFF
--- a/src/app/dashboard/surveys/page.tsx
+++ b/src/app/dashboard/surveys/page.tsx
@@ -1,17 +1,46 @@
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+"use client"
+
+import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { SurveyForm } from "@/components/organisms/survey-form"
+import { SurveyResponseTable } from "@/components/organisms/survey-response-table"
+import { useSurveyStore } from "@/store/survey-store"
 
 export default function SurveysPage() {
+  const { responses } = useSurveyStore()
+
   return (
-    <div className="flex-1 space-y-4 p-4 md:p-8 pt-6">
-      <h2 className="text-3xl font-bold tracking-tight">Survei Budaya Keselamatan</h2>
-      <Card>
-        <CardHeader>
-          <CardTitle>Halaman Dalam Pengembangan</CardTitle>
-        </CardHeader>
-        <CardContent>
-          <p>Fitur untuk mengelola survei budaya keselamatan akan segera tersedia.</p>
-        </CardContent>
-      </Card>
+    <div className="flex-1 space-y-4 p-4 pt-6 md:p-8">
+      <h2 className="text-3xl font-bold tracking-tight">
+        Survei Budaya Keselamatan
+      </h2>
+      <Tabs defaultValue="dashboard" className="space-y-4">
+        <TabsList className="text-lg">
+          <TabsTrigger value="dashboard">Dashboard</TabsTrigger>
+          <TabsTrigger value="form">Isi Survei</TabsTrigger>
+        </TabsList>
+        <TabsContent value="dashboard">
+          <Card>
+            <CardHeader>
+              <CardTitle className="text-2xl">Ringkasan Survei</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <p className="mb-4 text-lg">Total respon: {responses.length}</p>
+              <SurveyResponseTable />
+            </CardContent>
+          </Card>
+        </TabsContent>
+        <TabsContent value="form">
+          <Card>
+            <CardHeader>
+              <CardTitle className="text-2xl">Form Survei</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <SurveyForm />
+            </CardContent>
+          </Card>
+        </TabsContent>
+      </Tabs>
     </div>
-  );
+  )
 }

--- a/src/app/dashboard/surveys/page.tsx
+++ b/src/app/dashboard/surveys/page.tsx
@@ -1,46 +1,50 @@
 "use client"
 
-import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs"
+import { useState } from "react"
+import {
+  Dialog,
+  DialogTrigger,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Button } from "@/components/ui/button"
 import { SurveyForm } from "@/components/organisms/survey-form"
 import { SurveyResponseTable } from "@/components/organisms/survey-response-table"
 import { useSurveyStore } from "@/store/survey-store"
 
 export default function SurveysPage() {
   const { responses } = useSurveyStore()
+  const [open, setOpen] = useState(false)
 
   return (
     <div className="flex-1 space-y-4 p-4 pt-6 md:p-8">
-      <h2 className="text-3xl font-bold tracking-tight">
-        Survei Budaya Keselamatan
-      </h2>
-      <Tabs defaultValue="dashboard" className="space-y-4">
-        <TabsList className="text-lg">
-          <TabsTrigger value="dashboard">Dashboard</TabsTrigger>
-          <TabsTrigger value="form">Isi Survei</TabsTrigger>
-        </TabsList>
-        <TabsContent value="dashboard">
-          <Card>
-            <CardHeader>
-              <CardTitle className="text-2xl">Ringkasan Survei</CardTitle>
-            </CardHeader>
-            <CardContent>
-              <p className="mb-4 text-lg">Total respon: {responses.length}</p>
-              <SurveyResponseTable />
-            </CardContent>
-          </Card>
-        </TabsContent>
-        <TabsContent value="form">
-          <Card>
-            <CardHeader>
-              <CardTitle className="text-2xl">Form Survei</CardTitle>
-            </CardHeader>
-            <CardContent>
-              <SurveyForm />
-            </CardContent>
-          </Card>
-        </TabsContent>
-      </Tabs>
+      <div className="flex items-center justify-between">
+        <h2 className="text-3xl font-bold tracking-tight">
+          Survei Budaya Keselamatan
+        </h2>
+        <Dialog open={open} onOpenChange={setOpen}>
+          <DialogTrigger asChild>
+            <Button className="text-lg">Isi Survei</Button>
+          </DialogTrigger>
+          <DialogContent className="max-w-3xl">
+            <DialogHeader>
+              <DialogTitle className="text-2xl">Form Survei</DialogTitle>
+            </DialogHeader>
+            <SurveyForm onSuccess={() => setOpen(false)} />
+          </DialogContent>
+        </Dialog>
+      </div>
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-2xl">Ringkasan Survei</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <p className="mb-4 text-lg">Total respon: {responses.length}</p>
+          <SurveyResponseTable />
+        </CardContent>
+      </Card>
     </div>
   )
 }

--- a/src/components/organisms/survey-form.tsx
+++ b/src/components/organisms/survey-form.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import { useState } from "react"
 import { z } from "zod"
 import { useForm } from "react-hook-form"
 import { zodResolver } from "@hookform/resolvers/zod"
@@ -28,29 +29,63 @@ import { useToast } from "@/hooks/use-toast"
 const formSchema = z.object({
   unit: z.string().min(1, "Wajib diisi"),
   workDuration: z.string().min(1, "Wajib diisi"),
+  unitDuration: z.string().min(1, "Wajib diisi"),
+  weeklyHours: z.string().min(1, "Wajib diisi"),
+  directPatientContact: z.string().min(1, "Wajib diisi"),
   incidentsReported: z.string().min(1, "Wajib diisi"),
   safetyRating: z.string().min(1, "Wajib diisi"),
   comments: z.string().optional(),
 })
 
-export function SurveyForm() {
+type FormValues = z.infer<typeof formSchema>
+
+export function SurveyForm({ onSuccess }: { onSuccess?: () => void }) {
   const { addResponse } = useSurveyStore()
   const { toast } = useToast()
-  const form = useForm<z.infer<typeof formSchema>>({
+  const [step, setStep] = useState(0)
+
+  const form = useForm<FormValues>({
     resolver: zodResolver(formSchema),
     defaultValues: {
       unit: "",
       workDuration: "",
+      unitDuration: "",
+      weeklyHours: "",
+      directPatientContact: "",
       incidentsReported: "",
       safetyRating: "",
       comments: "",
     },
   })
 
-  function onSubmit(values: z.infer<typeof formSchema>) {
+  const steps: (keyof FormValues)[][] = [
+    [
+      "unit",
+      "unitDuration",
+      "workDuration",
+      "weeklyHours",
+      "directPatientContact",
+    ],
+    ["incidentsReported", "safetyRating", "comments"],
+  ]
+
+  function next() {
+    const fields = steps[step]
+    form.trigger(fields).then((valid) => {
+      if (valid) setStep((s) => s + 1)
+    })
+  }
+
+  function prev() {
+    setStep((s) => s - 1)
+  }
+
+  function onSubmit(values: FormValues) {
     addResponse(values)
     toast({ description: "Terima kasih atas partisipasi Anda." })
     form.reset()
+    setStep(0)
+    onSuccess?.()
   }
 
   return (
@@ -59,113 +94,213 @@ export function SurveyForm() {
         onSubmit={form.handleSubmit(onSubmit)}
         className="space-y-4 text-lg"
       >
-        <FormField
-          control={form.control}
-          name="unit"
-          render={({ field }) => (
-            <FormItem>
-              <FormLabel>Area / Unit Anda Bekerja</FormLabel>
-              <FormControl>
-                <Input {...field} className="text-lg" />
-              </FormControl>
-              <FormMessage />
-            </FormItem>
-          )}
-        />
+        {step === 0 && (
+          <>
+            <FormField
+              control={form.control}
+              name="unit"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Area / Unit Anda Bekerja</FormLabel>
+                  <FormControl>
+                    <Input {...field} className="text-lg" />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
 
-        <FormField
-          control={form.control}
-          name="workDuration"
-          render={({ field }) => (
-            <FormItem>
-              <FormLabel>
-                Sudah berapa lama Anda bekerja di rumah sakit ini?
-              </FormLabel>
-              <Select onValueChange={field.onChange} value={field.value}>
-                <FormControl>
-                  <SelectTrigger className="text-lg">
-                    <SelectValue placeholder="Pilih lama bekerja" />
-                  </SelectTrigger>
-                </FormControl>
-                <SelectContent>
-                  <SelectItem value="<1">Kurang dari 1 tahun</SelectItem>
-                  <SelectItem value="1-5">1 sampai 5 tahun</SelectItem>
-                  <SelectItem value="6-10">6 sampai 10 tahun</SelectItem>
-                  <SelectItem value=">10">Lebih dari 10 tahun</SelectItem>
-                </SelectContent>
-              </Select>
-              <FormMessage />
-            </FormItem>
-          )}
-        />
+            <FormField
+              control={form.control}
+              name="unitDuration"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>
+                    Sudah berapa lama Anda bekerja di area/unit kerja sekarang?
+                  </FormLabel>
+                  <Select onValueChange={field.onChange} value={field.value}>
+                    <FormControl>
+                      <SelectTrigger className="text-lg">
+                        <SelectValue placeholder="Pilih lama bekerja" />
+                      </SelectTrigger>
+                    </FormControl>
+                    <SelectContent>
+                      <SelectItem value="<1">Kurang dari 1 tahun</SelectItem>
+                      <SelectItem value="1-5">1 sampai 5 tahun</SelectItem>
+                      <SelectItem value="6-10">6 sampai 10 tahun</SelectItem>
+                      <SelectItem value=">10">Lebih dari 10 tahun</SelectItem>
+                    </SelectContent>
+                  </Select>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
 
-        <FormField
-          control={form.control}
-          name="incidentsReported"
-          render={({ field }) => (
-            <FormItem>
-              <FormLabel>
-                Jumlah insiden yang Anda laporkan dalam 12 bulan terakhir?
-              </FormLabel>
-              <Select onValueChange={field.onChange} value={field.value}>
-                <FormControl>
-                  <SelectTrigger className="text-lg">
-                    <SelectValue placeholder="Pilih jumlah laporan" />
-                  </SelectTrigger>
-                </FormControl>
-                <SelectContent>
-                  <SelectItem value="0">Tidak ada laporan</SelectItem>
-                  <SelectItem value="1-2">1 sampai 2 laporan</SelectItem>
-                  <SelectItem value="3-5">3 sampai 5 laporan</SelectItem>
-                  <SelectItem value=">5">Lebih dari 5 laporan</SelectItem>
-                </SelectContent>
-              </Select>
-              <FormMessage />
-            </FormItem>
-          )}
-        />
+            <FormField
+              control={form.control}
+              name="workDuration"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>
+                    Sudah berapa lama Anda bekerja di rumah sakit ini?
+                  </FormLabel>
+                  <Select onValueChange={field.onChange} value={field.value}>
+                    <FormControl>
+                      <SelectTrigger className="text-lg">
+                        <SelectValue placeholder="Pilih lama bekerja" />
+                      </SelectTrigger>
+                    </FormControl>
+                    <SelectContent>
+                      <SelectItem value="<1">Kurang dari 1 tahun</SelectItem>
+                      <SelectItem value="1-5">1 sampai 5 tahun</SelectItem>
+                      <SelectItem value="6-10">6 sampai 10 tahun</SelectItem>
+                      <SelectItem value=">10">Lebih dari 10 tahun</SelectItem>
+                    </SelectContent>
+                  </Select>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
 
-        <FormField
-          control={form.control}
-          name="safetyRating"
-          render={({ field }) => (
-            <FormItem>
-              <FormLabel>Penilaian keselamatan pasien di unit Anda</FormLabel>
-              <Select onValueChange={field.onChange} value={field.value}>
-                <FormControl>
-                  <SelectTrigger className="text-lg">
-                    <SelectValue placeholder="Pilih penilaian" />
-                  </SelectTrigger>
-                </FormControl>
-                <SelectContent>
-                  <SelectItem value="Sangat Baik">Sangat Baik</SelectItem>
-                  <SelectItem value="Baik">Baik</SelectItem>
-                  <SelectItem value="Cukup">Cukup</SelectItem>
-                  <SelectItem value="Kurang">Kurang</SelectItem>
-                  <SelectItem value="Buruk">Buruk</SelectItem>
-                </SelectContent>
-              </Select>
-              <FormMessage />
-            </FormItem>
-          )}
-        />
+            <FormField
+              control={form.control}
+              name="weeklyHours"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>
+                    Berapa jam per minggu Anda bekerja di rumah sakit ini?
+                  </FormLabel>
+                  <Select onValueChange={field.onChange} value={field.value}>
+                    <FormControl>
+                      <SelectTrigger className="text-lg">
+                        <SelectValue placeholder="Pilih jam kerja" />
+                      </SelectTrigger>
+                    </FormControl>
+                    <SelectContent>
+                      <SelectItem value="<20">Kurang dari 20 jam</SelectItem>
+                      <SelectItem value="20-39">20 sampai 39 jam</SelectItem>
+                      <SelectItem value="40-59">40 sampai 59 jam</SelectItem>
+                      <SelectItem value=">60">60 jam atau lebih</SelectItem>
+                    </SelectContent>
+                  </Select>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
 
-        <FormField
-          control={form.control}
-          name="comments"
-          render={({ field }) => (
-            <FormItem>
-              <FormLabel>Komentar Anda</FormLabel>
-              <FormControl>
-                <Textarea {...field} rows={4} className="text-lg" />
-              </FormControl>
-            </FormItem>
-          )}
-        />
+            <FormField
+              control={form.control}
+              name="directPatientContact"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>
+                    Apakah posisi Anda berinteraksi langsung dengan pasien?
+                  </FormLabel>
+                  <Select onValueChange={field.onChange} value={field.value}>
+                    <FormControl>
+                      <SelectTrigger className="text-lg">
+                        <SelectValue placeholder="Pilih jawaban" />
+                      </SelectTrigger>
+                    </FormControl>
+                    <SelectContent>
+                      <SelectItem value="Ya">Ya</SelectItem>
+                      <SelectItem value="Tidak">Tidak</SelectItem>
+                    </SelectContent>
+                  </Select>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+          </>
+        )}
 
-        <Button type="submit" className="text-lg">
-          Kirim
-        </Button>
+        {step === 1 && (
+          <>
+            <FormField
+              control={form.control}
+              name="incidentsReported"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>
+                    Jumlah insiden yang Anda laporkan dalam 12 bulan terakhir?
+                  </FormLabel>
+                  <Select onValueChange={field.onChange} value={field.value}>
+                    <FormControl>
+                      <SelectTrigger className="text-lg">
+                        <SelectValue placeholder="Pilih jumlah laporan" />
+                      </SelectTrigger>
+                    </FormControl>
+                    <SelectContent>
+                      <SelectItem value="0">Tidak ada laporan</SelectItem>
+                      <SelectItem value="1-2">1 sampai 2 laporan</SelectItem>
+                      <SelectItem value="3-5">3 sampai 5 laporan</SelectItem>
+                      <SelectItem value=">5">Lebih dari 5 laporan</SelectItem>
+                    </SelectContent>
+                  </Select>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <FormField
+              control={form.control}
+              name="safetyRating"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>
+                    Penilaian keselamatan pasien di unit Anda
+                  </FormLabel>
+                  <Select onValueChange={field.onChange} value={field.value}>
+                    <FormControl>
+                      <SelectTrigger className="text-lg">
+                        <SelectValue placeholder="Pilih penilaian" />
+                      </SelectTrigger>
+                    </FormControl>
+                    <SelectContent>
+                      <SelectItem value="Sangat Baik">Sangat Baik</SelectItem>
+                      <SelectItem value="Baik">Baik</SelectItem>
+                      <SelectItem value="Cukup">Cukup</SelectItem>
+                      <SelectItem value="Kurang">Kurang</SelectItem>
+                      <SelectItem value="Buruk">Buruk</SelectItem>
+                    </SelectContent>
+                  </Select>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <FormField
+              control={form.control}
+              name="comments"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Komentar Anda</FormLabel>
+                  <FormControl>
+                    <Textarea {...field} rows={4} className="text-lg" />
+                  </FormControl>
+                </FormItem>
+              )}
+            />
+          </>
+        )}
+
+        <div className="flex justify-between pt-4">
+          {step > 0 && (
+            <Button type="button" onClick={prev} className="text-lg">
+              Kembali
+            </Button>
+          )}
+          {step < steps.length - 1 && (
+            <Button type="button" onClick={next} className="ml-auto text-lg">
+              Lanjut
+            </Button>
+          )}
+          {step === steps.length - 1 && (
+            <Button type="submit" className="ml-auto text-lg">
+              Kirim
+            </Button>
+          )}
+        </div>
       </form>
     </Form>
   )

--- a/src/components/organisms/survey-form.tsx
+++ b/src/components/organisms/survey-form.tsx
@@ -25,6 +25,19 @@ import { Textarea } from "@/components/ui/textarea"
 import { Button } from "@/components/ui/button"
 import { useSurveyStore } from "@/store/survey-store"
 import { useToast } from "@/hooks/use-toast"
+import {
+  RadioGroup,
+  RadioGroupItem,
+} from "@/components/ui/radio-group"
+import { Label } from "@/components/ui/label"
+
+const likertOptions = [
+  "Sangat Setuju",
+  "Setuju",
+  "Netral",
+  "Tidak Setuju",
+  "Sangat Tidak Setuju",
+]
 
 const formSchema = z.object({
   name: z.string().min(1, "Wajib diisi"),
@@ -36,6 +49,11 @@ const formSchema = z.object({
   unitDuration: z.string().min(1, "Wajib diisi"),
   weeklyHours: z.string().min(1, "Wajib diisi"),
   directPatientContact: z.string().min(1, "Wajib diisi"),
+  managerPraise: z.string().min(1, "Wajib diisi"),
+  managerSuggestions: z.string().min(1, "Wajib diisi"),
+  managerPressure: z.string().min(1, "Wajib diisi"),
+  managerIgnore: z.string().min(1, "Wajib diisi"),
+  managerAware: z.string().min(1, "Wajib diisi"),
   incidentsReported: z.string().min(1, "Wajib diisi"),
   safetyRating: z.string().min(1, "Wajib diisi"),
   comments: z.string().optional(),
@@ -60,6 +78,11 @@ export function SurveyForm({ onSuccess }: { onSuccess?: () => void }) {
       unitDuration: "",
       weeklyHours: "",
       directPatientContact: "",
+      managerPraise: "",
+      managerSuggestions: "",
+      managerPressure: "",
+      managerIgnore: "",
+      managerAware: "",
       incidentsReported: "",
       safetyRating: "",
       comments: "",
@@ -74,6 +97,13 @@ export function SurveyForm({ onSuccess }: { onSuccess?: () => void }) {
       "workDuration",
       "weeklyHours",
       "directPatientContact",
+    ],
+    [
+      "managerPraise",
+      "managerSuggestions",
+      "managerPressure",
+      "managerIgnore",
+      "managerAware",
     ],
     ["incidentsReported", "safetyRating", "comments"],
   ]
@@ -302,6 +332,166 @@ export function SurveyForm({ onSuccess }: { onSuccess?: () => void }) {
         )}
 
         {step === 2 && (
+          <>
+            <FormField
+              control={form.control}
+              name="managerPraise"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>
+                    Manajer saya memberikan pujian jika melihat pekerjaan
+                    diselesaikan sesuai prosedur keselamatan pasien.
+                  </FormLabel>
+                  <FormControl>
+                    <RadioGroup
+                      onValueChange={field.onChange}
+                      value={field.value}
+                      className="grid gap-2"
+                    >
+                      {likertOptions.map((opt) => (
+                        <div
+                          className="flex items-center space-x-2 text-lg"
+                          key={opt}
+                        >
+                          <RadioGroupItem value={opt} id={`praise-${opt}`} />
+                          <Label htmlFor={`praise-${opt}`}>{opt}</Label>
+                        </div>
+                      ))}
+                    </RadioGroup>
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <FormField
+              control={form.control}
+              name="managerSuggestions"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>
+                    Manajer saya serius mempertimbangkan saran dari staf
+                    untuk meningkatkan keselamatan pasien.
+                  </FormLabel>
+                  <FormControl>
+                    <RadioGroup
+                      onValueChange={field.onChange}
+                      value={field.value}
+                      className="grid gap-2"
+                    >
+                      {likertOptions.map((opt) => (
+                        <div
+                          className="flex items-center space-x-2 text-lg"
+                          key={opt}
+                        >
+                          <RadioGroupItem value={opt} id={`suggest-${opt}`} />
+                          <Label htmlFor={`suggest-${opt}`}>{opt}</Label>
+                        </div>
+                      ))}
+                    </RadioGroup>
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <FormField
+              control={form.control}
+              name="managerPressure"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>
+                    Ketika tekanan pekerjaan meningkat, manajer saya
+                    menginginkan kami bekerja lebih cepat meski harus
+                    mengambil jalan pintas.
+                  </FormLabel>
+                  <FormControl>
+                    <RadioGroup
+                      onValueChange={field.onChange}
+                      value={field.value}
+                      className="grid gap-2"
+                    >
+                      {likertOptions.map((opt) => (
+                        <div
+                          className="flex items-center space-x-2 text-lg"
+                          key={opt}
+                        >
+                          <RadioGroupItem value={opt} id={`pressure-${opt}`} />
+                          <Label htmlFor={`pressure-${opt}`}>{opt}</Label>
+                        </div>
+                      ))}
+                    </RadioGroup>
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <FormField
+              control={form.control}
+              name="managerIgnore"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>
+                    Manajer saya mengabaikan masalah keselamatan pasien yang
+                    terjadi berulang.
+                  </FormLabel>
+                  <FormControl>
+                    <RadioGroup
+                      onValueChange={field.onChange}
+                      value={field.value}
+                      className="grid gap-2"
+                    >
+                      {likertOptions.map((opt) => (
+                        <div
+                          className="flex items-center space-x-2 text-lg"
+                          key={opt}
+                        >
+                          <RadioGroupItem value={opt} id={`ignore-${opt}`} />
+                          <Label htmlFor={`ignore-${opt}`}>{opt}</Label>
+                        </div>
+                      ))}
+                    </RadioGroup>
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <FormField
+              control={form.control}
+              name="managerAware"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>
+                    Manajer saya sangat mengetahui masalah keselamatan pasien
+                    di unit saya.
+                  </FormLabel>
+                  <FormControl>
+                    <RadioGroup
+                      onValueChange={field.onChange}
+                      value={field.value}
+                      className="grid gap-2"
+                    >
+                      {likertOptions.map((opt) => (
+                        <div
+                          className="flex items-center space-x-2 text-lg"
+                          key={opt}
+                        >
+                          <RadioGroupItem value={opt} id={`aware-${opt}`} />
+                          <Label htmlFor={`aware-${opt}`}>{opt}</Label>
+                        </div>
+                      ))}
+                    </RadioGroup>
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+          </>
+        )}
+
+        {step === 3 && (
           <>
             <FormField
               control={form.control}

--- a/src/components/organisms/survey-form.tsx
+++ b/src/components/organisms/survey-form.tsx
@@ -27,6 +27,10 @@ import { useSurveyStore } from "@/store/survey-store"
 import { useToast } from "@/hooks/use-toast"
 
 const formSchema = z.object({
+  name: z.string().min(1, "Wajib diisi"),
+  gender: z.string().min(1, "Wajib diisi"),
+  education: z.string().min(1, "Wajib diisi"),
+  profession: z.string().min(1, "Wajib diisi"),
   unit: z.string().min(1, "Wajib diisi"),
   workDuration: z.string().min(1, "Wajib diisi"),
   unitDuration: z.string().min(1, "Wajib diisi"),
@@ -47,6 +51,10 @@ export function SurveyForm({ onSuccess }: { onSuccess?: () => void }) {
   const form = useForm<FormValues>({
     resolver: zodResolver(formSchema),
     defaultValues: {
+      name: "",
+      gender: "",
+      education: "",
+      profession: "",
       unit: "",
       workDuration: "",
       unitDuration: "",
@@ -59,6 +67,7 @@ export function SurveyForm({ onSuccess }: { onSuccess?: () => void }) {
   })
 
   const steps: (keyof FormValues)[][] = [
+    ["name", "gender", "education", "profession"],
     [
       "unit",
       "unitDuration",
@@ -95,6 +104,84 @@ export function SurveyForm({ onSuccess }: { onSuccess?: () => void }) {
         className="space-y-4 text-lg"
       >
         {step === 0 && (
+          <>
+            <FormField
+              control={form.control}
+              name="name"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Nama</FormLabel>
+                  <FormControl>
+                    <Input {...field} className="text-lg" />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <FormField
+              control={form.control}
+              name="gender"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Jenis Kelamin</FormLabel>
+                  <Select onValueChange={field.onChange} value={field.value}>
+                    <FormControl>
+                      <SelectTrigger className="text-lg">
+                        <SelectValue placeholder="Pilih jenis kelamin" />
+                      </SelectTrigger>
+                    </FormControl>
+                    <SelectContent>
+                      <SelectItem value="Laki-laki">Laki-laki</SelectItem>
+                      <SelectItem value="Perempuan">Perempuan</SelectItem>
+                    </SelectContent>
+                  </Select>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <FormField
+              control={form.control}
+              name="education"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Pendidikan Terakhir</FormLabel>
+                  <Select onValueChange={field.onChange} value={field.value}>
+                    <FormControl>
+                      <SelectTrigger className="text-lg">
+                        <SelectValue placeholder="Pilih pendidikan" />
+                      </SelectTrigger>
+                    </FormControl>
+                    <SelectContent>
+                      <SelectItem value="SMP">SMP</SelectItem>
+                      <SelectItem value="SMA/SMK">SMA/SMK</SelectItem>
+                      <SelectItem value="D3">D3</SelectItem>
+                      <SelectItem value="S1">S1</SelectItem>
+                      <SelectItem value="S2">S2</SelectItem>
+                      <SelectItem value="S3">S3</SelectItem>
+                    </SelectContent>
+                  </Select>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <FormField
+              control={form.control}
+              name="profession"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Profesi</FormLabel>
+                  <Input {...field} className="text-lg" />
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+          </>
+        )}
+
+        {step === 1 && (
           <>
             <FormField
               control={form.control}
@@ -214,7 +301,7 @@ export function SurveyForm({ onSuccess }: { onSuccess?: () => void }) {
           </>
         )}
 
-        {step === 1 && (
+        {step === 2 && (
           <>
             <FormField
               control={form.control}

--- a/src/components/organisms/survey-form.tsx
+++ b/src/components/organisms/survey-form.tsx
@@ -1,0 +1,172 @@
+"use client"
+
+import { z } from "zod"
+import { useForm } from "react-hook-form"
+import { zodResolver } from "@hookform/resolvers/zod"
+
+import {
+  Form,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormControl,
+  FormMessage,
+} from "@/components/ui/form"
+import { Input } from "@/components/ui/input"
+import {
+  Select,
+  SelectTrigger,
+  SelectValue,
+  SelectContent,
+  SelectItem,
+} from "@/components/ui/select"
+import { Textarea } from "@/components/ui/textarea"
+import { Button } from "@/components/ui/button"
+import { useSurveyStore } from "@/store/survey-store"
+import { useToast } from "@/hooks/use-toast"
+
+const formSchema = z.object({
+  unit: z.string().min(1, "Wajib diisi"),
+  workDuration: z.string().min(1, "Wajib diisi"),
+  incidentsReported: z.string().min(1, "Wajib diisi"),
+  safetyRating: z.string().min(1, "Wajib diisi"),
+  comments: z.string().optional(),
+})
+
+export function SurveyForm() {
+  const { addResponse } = useSurveyStore()
+  const { toast } = useToast()
+  const form = useForm<z.infer<typeof formSchema>>({
+    resolver: zodResolver(formSchema),
+    defaultValues: {
+      unit: "",
+      workDuration: "",
+      incidentsReported: "",
+      safetyRating: "",
+      comments: "",
+    },
+  })
+
+  function onSubmit(values: z.infer<typeof formSchema>) {
+    addResponse(values)
+    toast({ description: "Terima kasih atas partisipasi Anda." })
+    form.reset()
+  }
+
+  return (
+    <Form {...form}>
+      <form
+        onSubmit={form.handleSubmit(onSubmit)}
+        className="space-y-4 text-lg"
+      >
+        <FormField
+          control={form.control}
+          name="unit"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Area / Unit Anda Bekerja</FormLabel>
+              <FormControl>
+                <Input {...field} className="text-lg" />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        <FormField
+          control={form.control}
+          name="workDuration"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>
+                Sudah berapa lama Anda bekerja di rumah sakit ini?
+              </FormLabel>
+              <Select onValueChange={field.onChange} value={field.value}>
+                <FormControl>
+                  <SelectTrigger className="text-lg">
+                    <SelectValue placeholder="Pilih lama bekerja" />
+                  </SelectTrigger>
+                </FormControl>
+                <SelectContent>
+                  <SelectItem value="<1">Kurang dari 1 tahun</SelectItem>
+                  <SelectItem value="1-5">1 sampai 5 tahun</SelectItem>
+                  <SelectItem value="6-10">6 sampai 10 tahun</SelectItem>
+                  <SelectItem value=">10">Lebih dari 10 tahun</SelectItem>
+                </SelectContent>
+              </Select>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        <FormField
+          control={form.control}
+          name="incidentsReported"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>
+                Jumlah insiden yang Anda laporkan dalam 12 bulan terakhir?
+              </FormLabel>
+              <Select onValueChange={field.onChange} value={field.value}>
+                <FormControl>
+                  <SelectTrigger className="text-lg">
+                    <SelectValue placeholder="Pilih jumlah laporan" />
+                  </SelectTrigger>
+                </FormControl>
+                <SelectContent>
+                  <SelectItem value="0">Tidak ada laporan</SelectItem>
+                  <SelectItem value="1-2">1 sampai 2 laporan</SelectItem>
+                  <SelectItem value="3-5">3 sampai 5 laporan</SelectItem>
+                  <SelectItem value=">5">Lebih dari 5 laporan</SelectItem>
+                </SelectContent>
+              </Select>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        <FormField
+          control={form.control}
+          name="safetyRating"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Penilaian keselamatan pasien di unit Anda</FormLabel>
+              <Select onValueChange={field.onChange} value={field.value}>
+                <FormControl>
+                  <SelectTrigger className="text-lg">
+                    <SelectValue placeholder="Pilih penilaian" />
+                  </SelectTrigger>
+                </FormControl>
+                <SelectContent>
+                  <SelectItem value="Sangat Baik">Sangat Baik</SelectItem>
+                  <SelectItem value="Baik">Baik</SelectItem>
+                  <SelectItem value="Cukup">Cukup</SelectItem>
+                  <SelectItem value="Kurang">Kurang</SelectItem>
+                  <SelectItem value="Buruk">Buruk</SelectItem>
+                </SelectContent>
+              </Select>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        <FormField
+          control={form.control}
+          name="comments"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Komentar Anda</FormLabel>
+              <FormControl>
+                <Textarea {...field} rows={4} className="text-lg" />
+              </FormControl>
+            </FormItem>
+          )}
+        />
+
+        <Button type="submit" className="text-lg">
+          Kirim
+        </Button>
+      </form>
+    </Form>
+  )
+}

--- a/src/components/organisms/survey-response-table.tsx
+++ b/src/components/organisms/survey-response-table.tsx
@@ -20,7 +20,10 @@ export function SurveyResponseTable() {
     const header = [
       "Waktu",
       "Unit",
-      "Lama Bekerja",
+      "Lama di Unit",
+      "Lama di RS",
+      "Jam per Minggu",
+      "Kontak Pasien",
       "Jumlah Laporan",
       "Penilaian",
       "Komentar",
@@ -28,7 +31,10 @@ export function SurveyResponseTable() {
     const rows = responses.map((r) => [
       new Date(r.submittedAt).toLocaleDateString("id-ID"),
       r.unit,
+      r.unitDuration,
       r.workDuration,
+      r.weeklyHours,
+      r.directPatientContact,
       r.incidentsReported,
       r.safetyRating,
       r.comments ?? "",
@@ -67,7 +73,10 @@ export function SurveyResponseTable() {
               <TableHead>No</TableHead>
               <TableHead>Tanggal</TableHead>
               <TableHead>Unit</TableHead>
-              <TableHead>Lama Bekerja</TableHead>
+              <TableHead>Lama di Unit</TableHead>
+              <TableHead>Lama di RS</TableHead>
+              <TableHead>Jam/Minggu</TableHead>
+              <TableHead>Kontak Pasien</TableHead>
               <TableHead>Laporan</TableHead>
               <TableHead>Penilaian</TableHead>
               <TableHead>Komentar</TableHead>
@@ -76,7 +85,7 @@ export function SurveyResponseTable() {
           <TableBody>
             {responses.length === 0 ? (
               <TableRow>
-                <TableCell colSpan={7} className="text-center">
+                <TableCell colSpan={9} className="text-center">
                   Belum ada data.
                 </TableCell>
               </TableRow>
@@ -88,7 +97,10 @@ export function SurveyResponseTable() {
                     {new Date(r.submittedAt).toLocaleDateString("id-ID")}
                   </TableCell>
                   <TableCell>{r.unit}</TableCell>
+                  <TableCell>{r.unitDuration}</TableCell>
                   <TableCell>{r.workDuration}</TableCell>
+                  <TableCell>{r.weeklyHours}</TableCell>
+                  <TableCell>{r.directPatientContact}</TableCell>
                   <TableCell>{r.incidentsReported}</TableCell>
                   <TableCell>{r.safetyRating}</TableCell>
                   <TableCell>{r.comments || "-"}</TableCell>

--- a/src/components/organisms/survey-response-table.tsx
+++ b/src/components/organisms/survey-response-table.tsx
@@ -28,6 +28,11 @@ export function SurveyResponseTable() {
       "Lama di RS",
       "Jam per Minggu",
       "Kontak Pasien",
+      "Pujian Manajer",
+      "Saran Keselamatan",
+      "Tekanan Kerja",
+      "Mengabaikan Masalah",
+      "Pemahaman Manajer",
       "Jumlah Laporan",
       "Penilaian",
       "Komentar",
@@ -43,6 +48,11 @@ export function SurveyResponseTable() {
       r.workDuration,
       r.weeklyHours,
       r.directPatientContact,
+      r.managerPraise,
+      r.managerSuggestions,
+      r.managerPressure,
+      r.managerIgnore,
+      r.managerAware,
       r.incidentsReported,
       r.safetyRating,
       r.comments ?? "",
@@ -89,6 +99,11 @@ export function SurveyResponseTable() {
               <TableHead>Lama di RS</TableHead>
               <TableHead>Jam/Minggu</TableHead>
               <TableHead>Kontak Pasien</TableHead>
+              <TableHead>Pujian Manajer</TableHead>
+              <TableHead>Saran</TableHead>
+              <TableHead>Tekanan</TableHead>
+              <TableHead>Masalah Diabaikan</TableHead>
+              <TableHead>Pemahaman</TableHead>
               <TableHead>Laporan</TableHead>
               <TableHead>Penilaian</TableHead>
               <TableHead>Komentar</TableHead>
@@ -97,7 +112,7 @@ export function SurveyResponseTable() {
           <TableBody>
             {responses.length === 0 ? (
               <TableRow>
-                <TableCell colSpan={13} className="text-center">
+                <TableCell colSpan={19} className="text-center">
                   Belum ada data.
                 </TableCell>
               </TableRow>
@@ -117,6 +132,11 @@ export function SurveyResponseTable() {
                   <TableCell>{r.workDuration}</TableCell>
                   <TableCell>{r.weeklyHours}</TableCell>
                   <TableCell>{r.directPatientContact}</TableCell>
+                  <TableCell>{r.managerPraise}</TableCell>
+                  <TableCell>{r.managerSuggestions}</TableCell>
+                  <TableCell>{r.managerPressure}</TableCell>
+                  <TableCell>{r.managerIgnore}</TableCell>
+                  <TableCell>{r.managerAware}</TableCell>
                   <TableCell>{r.incidentsReported}</TableCell>
                   <TableCell>{r.safetyRating}</TableCell>
                   <TableCell>{r.comments || "-"}</TableCell>

--- a/src/components/organisms/survey-response-table.tsx
+++ b/src/components/organisms/survey-response-table.tsx
@@ -19,6 +19,10 @@ export function SurveyResponseTable() {
     if (responses.length === 0) return
     const header = [
       "Waktu",
+      "Nama",
+      "Jenis Kelamin",
+      "Pendidikan",
+      "Profesi",
       "Unit",
       "Lama di Unit",
       "Lama di RS",
@@ -30,6 +34,10 @@ export function SurveyResponseTable() {
     ]
     const rows = responses.map((r) => [
       new Date(r.submittedAt).toLocaleDateString("id-ID"),
+      r.name,
+      r.gender,
+      r.education,
+      r.profession,
       r.unit,
       r.unitDuration,
       r.workDuration,
@@ -72,6 +80,10 @@ export function SurveyResponseTable() {
             <TableRow>
               <TableHead>No</TableHead>
               <TableHead>Tanggal</TableHead>
+              <TableHead>Nama</TableHead>
+              <TableHead>Jenis Kelamin</TableHead>
+              <TableHead>Pendidikan</TableHead>
+              <TableHead>Profesi</TableHead>
               <TableHead>Unit</TableHead>
               <TableHead>Lama di Unit</TableHead>
               <TableHead>Lama di RS</TableHead>
@@ -85,7 +97,7 @@ export function SurveyResponseTable() {
           <TableBody>
             {responses.length === 0 ? (
               <TableRow>
-                <TableCell colSpan={9} className="text-center">
+                <TableCell colSpan={13} className="text-center">
                   Belum ada data.
                 </TableCell>
               </TableRow>
@@ -96,6 +108,10 @@ export function SurveyResponseTable() {
                   <TableCell>
                     {new Date(r.submittedAt).toLocaleDateString("id-ID")}
                   </TableCell>
+                  <TableCell>{r.name}</TableCell>
+                  <TableCell>{r.gender}</TableCell>
+                  <TableCell>{r.education}</TableCell>
+                  <TableCell>{r.profession}</TableCell>
                   <TableCell>{r.unit}</TableCell>
                   <TableCell>{r.unitDuration}</TableCell>
                   <TableCell>{r.workDuration}</TableCell>

--- a/src/components/organisms/survey-response-table.tsx
+++ b/src/components/organisms/survey-response-table.tsx
@@ -1,0 +1,103 @@
+"use client"
+
+import { useSurveyStore } from "@/store/survey-store"
+import {
+  Table,
+  TableHeader,
+  TableRow,
+  TableHead,
+  TableBody,
+  TableCell,
+} from "@/components/ui/table"
+import { Button } from "@/components/ui/button"
+import { Download } from "lucide-react"
+
+export function SurveyResponseTable() {
+  const { responses } = useSurveyStore()
+
+  const handleDownload = () => {
+    if (responses.length === 0) return
+    const header = [
+      "Waktu",
+      "Unit",
+      "Lama Bekerja",
+      "Jumlah Laporan",
+      "Penilaian",
+      "Komentar",
+    ]
+    const rows = responses.map((r) => [
+      new Date(r.submittedAt).toLocaleDateString("id-ID"),
+      r.unit,
+      r.workDuration,
+      r.incidentsReported,
+      r.safetyRating,
+      r.comments ?? "",
+    ])
+    const csv = [header, ...rows]
+      .map((row) =>
+        row.map((val) => `"${String(val).replace(/"/g, '""')}"`).join(",")
+      )
+      .join("\n")
+    const blob = new Blob([csv], { type: "text/csv;charset=utf-8;" })
+    const url = URL.createObjectURL(blob)
+    const link = document.createElement("a")
+    link.href = url
+    link.download = "survei-budaya.csv"
+    link.click()
+    URL.revokeObjectURL(url)
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <h3 className="text-xl font-semibold">Hasil Survei</h3>
+        <Button
+          onClick={handleDownload}
+          disabled={responses.length === 0}
+          className="text-lg"
+        >
+          <Download className="mr-2 h-5 w-5" />
+          Unduh Laporan
+        </Button>
+      </div>
+      <div className="overflow-x-auto rounded-md border">
+        <Table className="text-lg">
+          <TableHeader>
+            <TableRow>
+              <TableHead>No</TableHead>
+              <TableHead>Tanggal</TableHead>
+              <TableHead>Unit</TableHead>
+              <TableHead>Lama Bekerja</TableHead>
+              <TableHead>Laporan</TableHead>
+              <TableHead>Penilaian</TableHead>
+              <TableHead>Komentar</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {responses.length === 0 ? (
+              <TableRow>
+                <TableCell colSpan={7} className="text-center">
+                  Belum ada data.
+                </TableCell>
+              </TableRow>
+            ) : (
+              responses.map((r, i) => (
+                <TableRow key={r.id}>
+                  <TableCell>{i + 1}</TableCell>
+                  <TableCell>
+                    {new Date(r.submittedAt).toLocaleDateString("id-ID")}
+                  </TableCell>
+                  <TableCell>{r.unit}</TableCell>
+                  <TableCell>{r.workDuration}</TableCell>
+                  <TableCell>{r.incidentsReported}</TableCell>
+                  <TableCell>{r.safetyRating}</TableCell>
+                  <TableCell>{r.comments || "-"}</TableCell>
+                </TableRow>
+              ))
+            )}
+          </TableBody>
+        </Table>
+      </div>
+    </div>
+  )
+}

--- a/src/store/survey-store.ts
+++ b/src/store/survey-store.ts
@@ -14,6 +14,11 @@ export type SurveyResponse = {
   unitDuration: string
   weeklyHours: string
   directPatientContact: string
+  managerPraise: string
+  managerSuggestions: string
+  managerPressure: string
+  managerIgnore: string
+  managerAware: string
   incidentsReported: string
   safetyRating: string
   comments?: string

--- a/src/store/survey-store.ts
+++ b/src/store/survey-store.ts
@@ -7,6 +7,9 @@ export type SurveyResponse = {
   id: string
   unit: string
   workDuration: string
+  unitDuration: string
+  weeklyHours: string
+  directPatientContact: string
   incidentsReported: string
   safetyRating: string
   comments?: string

--- a/src/store/survey-store.ts
+++ b/src/store/survey-store.ts
@@ -5,6 +5,10 @@ import { persist } from "zustand/middleware"
 
 export type SurveyResponse = {
   id: string
+  name: string
+  gender: string
+  education: string
+  profession: string
   unit: string
   workDuration: string
   unitDuration: string

--- a/src/store/survey-store.ts
+++ b/src/store/survey-store.ts
@@ -1,0 +1,39 @@
+"use client"
+
+import { create } from "zustand"
+import { persist } from "zustand/middleware"
+
+export type SurveyResponse = {
+  id: string
+  unit: string
+  workDuration: string
+  incidentsReported: string
+  safetyRating: string
+  comments?: string
+  submittedAt: string
+}
+
+type SurveyState = {
+  responses: SurveyResponse[]
+  addResponse: (data: Omit<SurveyResponse, "id" | "submittedAt">) => void
+}
+
+export const useSurveyStore = create<SurveyState>()(
+  persist(
+    (set) => ({
+      responses: [],
+      addResponse: (data) =>
+        set((state) => ({
+          responses: [
+            ...state.responses,
+            {
+              id: Date.now().toString(),
+              submittedAt: new Date().toISOString(),
+              ...data,
+            },
+          ],
+        })),
+    }),
+    { name: "survey-store" }
+  )
+)


### PR DESCRIPTION
## Summary
- implement local store for survey responses
- add user-friendly survey form and dashboard with CSV export

## Testing
- `npm run lint`
- `npm run typecheck` (fails: TS errors in existing files)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68abb60b03208325b7e1ce9eb4408001