### PR TITLE
Implement incident API with Prisma and user-friendly chronology

### DIFF
--- a/src/app/api/incidents/[id]/route.ts
+++ b/src/app/api/incidents/[id]/route.ts
@@ -1,0 +1,20 @@
+import { NextResponse } from "next/server"
+import { prisma } from "@/lib/prisma"
+import { formatChronology } from "@/lib/utils"
+
+export async function PATCH(req: Request, { params }: { params: { id: string } }) {
+  const data = await req.json()
+  const incident = await prisma.incident.update({
+    where: { id: params.id },
+    data: {
+      ...data,
+      chronology: data.chronology !== undefined ? formatChronology(data.chronology) : undefined,
+    },
+  })
+  return NextResponse.json({ incident })
+}
+
+export async function DELETE(_req: Request, { params }: { params: { id: string } }) {
+  await prisma.incident.delete({ where: { id: params.id } })
+  return NextResponse.json({ ok: true })
+}

--- a/src/app/api/incidents/route.ts
+++ b/src/app/api/incidents/route.ts
@@ -23,16 +23,24 @@ export async function GET() {
 
 export async function POST(req: Request) {
   const user = await getCurrentUser()
-  if (!user) return NextResponse.json({ error: "Not authenticated" }, { status: 401 })
+  if (!user)
+    return NextResponse.json({ error: "Not authenticated" }, { status: 401 })
 
-  const data = await req.json()
+  try {
+    const data = await req.json()
+    const incident = await prisma.incident.create({
+      data: {
+        ...data,
+        chronology: data.chronology ? formatChronology(data.chronology) : null,
+      },
+    })
 
-  const incident = await prisma.incident.create({
-    data: {
-      ...data,
-      chronology: data.chronology ? formatChronology(data.chronology) : null,
-    },
-  })
-
-  return NextResponse.json({ incident })
+    return NextResponse.json({ incident })
+  } catch (error) {
+    console.error("Failed to create incident", error)
+    return NextResponse.json(
+      { error: "Failed to create incident" },
+      { status: 500 }
+    )
+  }
 }

--- a/src/app/api/incidents/route.ts
+++ b/src/app/api/incidents/route.ts
@@ -1,0 +1,38 @@
+import { NextResponse } from "next/server"
+import { prisma } from "@/lib/prisma"
+import { getCurrentUser } from "@/lib/actions/auth"
+import { formatChronology } from "@/lib/utils"
+
+export async function GET() {
+  const user = await getCurrentUser()
+  if (!user) return NextResponse.json({ incidents: [] }, { status: 401 })
+
+  const userIsCentral = [
+    "ADMIN_SISTEM",
+    "DIREKTUR",
+    "SUB_KOMITE_KESELAMATAN_PASIEN",
+  ].includes(user.role)
+
+  const incidents = await prisma.incident.findMany({
+    where: userIsCentral ? {} : { relatedUnit: user.unit || undefined },
+    orderBy: { date: "desc" },
+  })
+
+  return NextResponse.json({ incidents })
+}
+
+export async function POST(req: Request) {
+  const user = await getCurrentUser()
+  if (!user) return NextResponse.json({ error: "Not authenticated" }, { status: 401 })
+
+  const data = await req.json()
+
+  const incident = await prisma.incident.create({
+    data: {
+      ...data,
+      chronology: data.chronology ? formatChronology(data.chronology) : null,
+    },
+  })
+
+  return NextResponse.json({ incident })
+}

--- a/src/app/api/indicators/[id]/route.ts
+++ b/src/app/api/indicators/[id]/route.ts
@@ -1,23 +1,70 @@
 import { NextResponse } from "next/server"
 import { prisma } from "@/lib/prisma"
+import { getCurrentUser } from "@/lib/actions/auth"
 
 export async function PATCH(req: Request, { params }: { params: { id: string } }) {
-  const data = await req.json()
-  const indicator = await prisma.indicator.update({
-    where: { id: params.id },
-    data: {
-      period: data.period,
-      numerator: data.numerator !== undefined ? parseFloat(data.numerator) : undefined,
-      denominator: data.denominator !== undefined ? parseFloat(data.denominator) : undefined,
+  const user = await getCurrentUser()
+  if (!user)
+    return NextResponse.json({ error: "Not authenticated" }, { status: 401 })
+
+  try {
+    const data = await req.json()
+
+    const updateData: any = {
       analysisNotes: data.analysisNotes,
       followUpPlan: data.followUpPlan,
-    },
-    include: { submission: true }
-  })
-  return NextResponse.json({ indicator })
+    }
+
+    if (data.period) {
+      const period = new Date(data.period)
+      if (isNaN(period.getTime())) {
+        return NextResponse.json({ error: "Invalid period" }, { status: 400 })
+      }
+      updateData.period = period
+    }
+    if (data.numerator !== undefined) {
+      const numerator = Number(data.numerator)
+      if (isNaN(numerator)) {
+        return NextResponse.json({ error: "Invalid numerator" }, { status: 400 })
+      }
+      updateData.numerator = numerator
+    }
+    if (data.denominator !== undefined) {
+      const denominator = Number(data.denominator)
+      if (isNaN(denominator)) {
+        return NextResponse.json({ error: "Invalid denominator" }, { status: 400 })
+      }
+      updateData.denominator = denominator
+    }
+
+    const indicator = await prisma.indicator.update({
+      where: { id: params.id },
+      data: updateData,
+      include: { submission: true },
+    })
+    return NextResponse.json({ indicator })
+  } catch (error) {
+    console.error("Failed to update indicator", error)
+    return NextResponse.json(
+      { error: "Failed to update indicator" },
+      { status: 500 }
+    )
+  }
 }
 
 export async function DELETE(_req: Request, { params }: { params: { id: string } }) {
-  await prisma.indicator.delete({ where: { id: params.id } })
-  return NextResponse.json({ ok: true })
+  const user = await getCurrentUser()
+  if (!user)
+    return NextResponse.json({ error: "Not authenticated" }, { status: 401 })
+
+  try {
+    await prisma.indicator.delete({ where: { id: params.id } })
+    return NextResponse.json({ ok: true })
+  } catch (error) {
+    console.error("Failed to delete indicator", error)
+    return NextResponse.json(
+      { error: "Failed to delete indicator" },
+      { status: 500 }
+    )
+  }
 }

--- a/src/app/api/indicators/route.ts
+++ b/src/app/api/indicators/route.ts
@@ -27,12 +27,29 @@ export async function POST(req: Request) {
 
   try {
     const data = await req.json()
+
+    const period = new Date(data.period)
+    const numerator = Number(data.numerator)
+    const denominator = Number(data.denominator)
+
+    if (
+      !data.submissionId ||
+      isNaN(period.getTime()) ||
+      isNaN(numerator) ||
+      isNaN(denominator)
+    ) {
+      return NextResponse.json(
+        { error: "Invalid indicator data" },
+        { status: 400 }
+      )
+    }
+
     const indicator = await prisma.indicator.create({
       data: {
         submissionId: data.submissionId,
-        period: data.period,
-        numerator: parseFloat(data.numerator),
-        denominator: parseFloat(data.denominator),
+        period,
+        numerator,
+        denominator,
         analysisNotes: data.analysisNotes,
         followUpPlan: data.followUpPlan,
       },

--- a/src/app/api/indicators/route.ts
+++ b/src/app/api/indicators/route.ts
@@ -21,17 +21,29 @@ export async function GET() {
 }
 
 export async function POST(req: Request) {
-  const data = await req.json()
-  const indicator = await prisma.indicator.create({
-    data: {
-      submissionId: data.submissionId,
-      period: data.period,
-      numerator: parseFloat(data.numerator),
-      denominator: parseFloat(data.denominator),
-      analysisNotes: data.analysisNotes,
-      followUpPlan: data.followUpPlan,
-    },
-    include: { submission: true }
-  })
-  return NextResponse.json({ indicator })
+  const user = await getCurrentUser()
+  if (!user)
+    return NextResponse.json({ error: "Not authenticated" }, { status: 401 })
+
+  try {
+    const data = await req.json()
+    const indicator = await prisma.indicator.create({
+      data: {
+        submissionId: data.submissionId,
+        period: data.period,
+        numerator: parseFloat(data.numerator),
+        denominator: parseFloat(data.denominator),
+        analysisNotes: data.analysisNotes,
+        followUpPlan: data.followUpPlan,
+      },
+      include: { submission: true },
+    })
+    return NextResponse.json({ indicator })
+  } catch (error) {
+    console.error("Failed to create indicator", error)
+    return NextResponse.json(
+      { error: "Failed to create indicator" },
+      { status: 500 }
+    )
+  }
 }

--- a/src/app/api/risks/[id]/route.ts
+++ b/src/app/api/risks/[id]/route.ts
@@ -1,0 +1,38 @@
+import { NextResponse } from "next/server"
+import { prisma } from "@/lib/prisma"
+import { getCurrentUser } from "@/lib/actions/auth"
+
+export async function PATCH(req: Request, { params }: { params: { id: string } }) {
+  const user = await getCurrentUser()
+  if (!user) return NextResponse.json({ error: "Not authenticated" }, { status: 401 })
+
+  try {
+    const data = await req.json()
+    const risk = await prisma.risk.update({
+      where: { id: params.id },
+      data: {
+        ...data,
+        dueDate: data.dueDate ? new Date(data.dueDate) : undefined,
+        residualConsequence: data.residualConsequence ?? undefined,
+        residualLikelihood: data.residualLikelihood ?? undefined,
+      },
+    })
+    return NextResponse.json({ risk })
+  } catch (error) {
+    console.error("Failed to update risk", error)
+    return NextResponse.json({ error: "Failed to update risk" }, { status: 500 })
+  }
+}
+
+export async function DELETE(req: Request, { params }: { params: { id: string } }) {
+  const user = await getCurrentUser()
+  if (!user) return NextResponse.json({ error: "Not authenticated" }, { status: 401 })
+
+  try {
+    await prisma.risk.delete({ where: { id: params.id } })
+    return NextResponse.json({ ok: true })
+  } catch (error) {
+    console.error("Failed to delete risk", error)
+    return NextResponse.json({ error: "Failed to delete risk" }, { status: 500 })
+  }
+}

--- a/src/app/api/risks/route.ts
+++ b/src/app/api/risks/route.ts
@@ -1,0 +1,50 @@
+import { NextResponse } from "next/server"
+import { prisma } from "@/lib/prisma"
+import { getCurrentUser } from "@/lib/actions/auth"
+
+export async function GET() {
+  const user = await getCurrentUser()
+  if (!user) return NextResponse.json({ risks: [] }, { status: 401 })
+
+  const userIsCentral = ["ADMIN_SISTEM", "DIREKTUR", "SUB_KOMITE_MANAJEMEN_RISIKO"].includes(user.role)
+
+  const risks = await prisma.risk.findMany({
+    where: userIsCentral ? {} : { unit: user.unit || undefined },
+    include: { pic: { select: { name: true } } },
+    orderBy: { createdAt: "desc" }
+  })
+
+  return NextResponse.json({ risks })
+}
+
+export async function POST(req: Request) {
+  const user = await getCurrentUser()
+  if (!user) return NextResponse.json({ error: "Not authenticated" }, { status: 401 })
+
+  try {
+    const data = await req.json()
+    const risk = await prisma.risk.create({
+      data: {
+        unit: data.unit,
+        source: data.source,
+        description: data.description,
+        cause: data.cause,
+        category: data.category,
+        consequence: Number(data.consequence),
+        likelihood: Number(data.likelihood),
+        controllability: Number(data.controllability),
+        evaluation: data.evaluation,
+        actionPlan: data.actionPlan,
+        dueDate: data.dueDate ? new Date(data.dueDate) : undefined,
+        status: data.status,
+        residualConsequence: data.residualConsequence ?? undefined,
+        residualLikelihood: data.residualLikelihood ?? undefined,
+        reportNotes: data.reportNotes ?? undefined,
+      },
+    })
+    return NextResponse.json({ risk })
+  } catch (error) {
+    console.error("Failed to create risk", error)
+    return NextResponse.json({ error: "Failed to create risk" }, { status: 500 })
+  }
+}

--- a/src/components/organisms/incident-detail-dialog.tsx
+++ b/src/components/organisms/incident-detail-dialog.tsx
@@ -6,6 +6,7 @@ import { Button } from "@/components/ui/button"
 import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog"
 import { Separator } from "@/components/ui/separator"
 import { Incident } from "@/store/incident-store"
+import { formatChronology } from "@/lib/utils"
 
 const DetailSection = ({ title, children }: { title: string, children: React.ReactNode }) => (
     <div className="space-y-2">
@@ -24,7 +25,7 @@ const DetailItem = ({ label, value }: { label: string, value: React.ReactNode })
 const FullWidthDetailItem = ({ label, value }: { label: string, value: React.ReactNode }) => (
     <div className="md:col-span-2">
         <p className="text-muted-foreground">{label}</p>
-        <p className="font-medium whitespace-pre-wrap">{value || "-"}</p>
+        <p className="font-medium whitespace-pre-wrap leading-relaxed text-justify">{value || "-"}</p>
     </div>
 )
 
@@ -65,7 +66,7 @@ export const IncidentDetailDialog = ({ incident, open, onOpenChange }: IncidentD
                          <DetailItem label="Insiden Mengenai" value={incident.incidentSubject} />
                          <DetailItem label="Lokasi Insiden" value={incident.incidentLocation} />
                          <DetailItem label="Unit Terkait" value={incident.relatedUnit} />
-                         <FullWidthDetailItem label="Kronologis Insiden" value={incident.chronology} />
+                         <FullWidthDetailItem label="Kronologis Insiden" value={formatChronology(incident.chronology || "")} />
                     </DetailSection>
                     <Separator />
                     <DetailSection title="Tindak Lanjut & Analisis">

--- a/src/components/organisms/incident-report-form.tsx
+++ b/src/components/organisms/incident-report-form.tsx
@@ -44,6 +44,16 @@ export function IncidentReportForm({ setOpen, incident }: IncidentReportFormProp
     const handleSave = async () => {
         const finalData = { ...formData } as Omit<Incident, 'id' | 'date' | 'status'>;
 
+        Object.keys(finalData).forEach((key) => {
+            // @ts-ignore
+            if (finalData[key] === '') delete finalData[key]
+        })
+
+        if (!finalData.type || !finalData.severity) {
+            toast({ title: "Data Belum Lengkap", description: "Jenis insiden dan grading risiko wajib diisi." });
+            return;
+        }
+
         if (isEditMode && incident.id) {
             await updateIncident(incident.id, finalData)
             addLog({ user: currentUser?.name || 'System', action: 'UPDATE_INCIDENT', details: `Laporan insiden ${incident.id} diperbarui.` })

--- a/src/components/organisms/incident-report-form/step1-patient-data.tsx
+++ b/src/components/organisms/incident-report-form/step1-patient-data.tsx
@@ -39,18 +39,18 @@ export function Step1PatientData({ data, onUpdate }: StepProps) {
         <div className="space-y-6">
             <SectionTitle>Data Pasien (diisi oleh perawat)</SectionTitle>
             <div className="grid grid-cols-1 md:grid-cols-2 gap-x-6 gap-y-4">
-                <FormInputText id="patientName" label="Nama Pasien" placeholder="Masukkan nama pasien" value={data.patientName} onChange={e => onUpdate({ patientName: e.target.value })}/>
-                <FormInputText id="medicalRecordNumber" label="No. Rekam Medis" placeholder="Masukkan nomor CM" value={data.medicalRecordNumber} onChange={e => onUpdate({ medicalRecordNumber: e.target.value })}/>
-                <FormInputRadio id="gender" label="Jenis Kelamin" items={genderOptions} value={data.gender} onValueChange={val => onUpdate({ gender: val })} />
-                <FormInputRadio id="age-group" label="Kelompok Umur" items={ageGroupOptions} orientation="vertical" value={data.ageGroup} onValueChange={val => onUpdate({ ageGroup: val })}/>
-                <FormInputSelect id="payer" label="Penanggung Biaya" placeholder="Pilih penanggung biaya" items={payerOptions} value={data.payer} onValueChange={val => onUpdate({ payer: val })} />
+                <FormInputText id="patientName" label="Nama Pasien" placeholder="Masukkan nama pasien" value={data.patientName ?? ""} onChange={e => onUpdate({ patientName: e.target.value })}/>
+                <FormInputText id="medicalRecordNumber" label="No. Rekam Medis" placeholder="Masukkan nomor CM" value={data.medicalRecordNumber ?? ""} onChange={e => onUpdate({ medicalRecordNumber: e.target.value })}/>
+                <FormInputRadio id="gender" label="Jenis Kelamin" items={genderOptions} value={data.gender ?? ""} onValueChange={val => onUpdate({ gender: val })} />
+                <FormInputRadio id="age-group" label="Kelompok Umur" items={ageGroupOptions} orientation="vertical" value={data.ageGroup ?? ""} onValueChange={val => onUpdate({ ageGroup: val })}/>
+                <FormInputSelect id="payer" label="Penanggung Biaya" placeholder="Pilih penanggung biaya" items={payerOptions} value={data.payer ?? ""} onValueChange={val => onUpdate({ payer: val })} />
             </div>
             <Separator />
             <SectionTitle>Informasi Perawatan</SectionTitle>
              <div className="grid grid-cols-1 md:grid-cols-2 gap-x-6 gap-y-4">
                 <FormInputDate id="entry-date" label="Tanggal Masuk RS" selected={data.entryDate ? new Date(data.entryDate) : undefined} onSelect={date => onUpdate({ entryDate: date?.toISOString() })}/>
-                <FormInputTime id="entry-time" label="Jam Masuk RS" value={data.entryTime} onChange={e => onUpdate({ entryTime: e.target.value })}/>
-                <FormInputSelect id="careRoom" label="Ruangan Perawatan" placeholder="Pilih ruangan" items={unitOptions} value={data.careRoom} onValueChange={val => onUpdate({ careRoom: val })} />
+                <FormInputTime id="entry-time" label="Jam Masuk RS" value={data.entryTime ?? ""} onChange={e => onUpdate({ entryTime: e.target.value })}/>
+                <FormInputSelect id="careRoom" label="Ruangan Perawatan" placeholder="Pilih ruangan" items={unitOptions} value={data.careRoom ?? ""} onValueChange={val => onUpdate({ careRoom: val })} />
             </div>
         </div>
     )

--- a/src/components/organisms/incident-report-form/step2-incident-details.tsx
+++ b/src/components/organisms/incident-report-form/step2-incident-details.tsx
@@ -37,13 +37,13 @@ export function Step2IncidentDetails({ data, onUpdate }: StepProps) {
             <SectionTitle>Rincian Kejadian</SectionTitle>
              <div className="grid grid-cols-1 md:grid-cols-2 gap-x-6 gap-y-4">
                 <FormInputDate id="incident-date" label="Tanggal Insiden" selected={data.incidentDate ? new Date(data.incidentDate) : undefined} onSelect={date => onUpdate({ incidentDate: date?.toISOString() })} />
-                <FormInputTime id="incident-time" label="Jam Insiden" value={data.incidentTime} onChange={e => onUpdate({ incidentTime: e.target.value })} />
+                <FormInputTime id="incident-time" label="Jam Insiden" value={data.incidentTime ?? ""} onChange={e => onUpdate({ incidentTime: e.target.value })} />
             </div>
-            <FormInputTextarea id="chronology" label="Kronologis Insiden" placeholder="Jelaskan secara singkat bagaimana insiden terjadi." value={data.chronology} onChange={e => onUpdate({ chronology: e.target.value })} containerClassName="grid grid-cols-1 md:grid-cols-form-label-full gap-x-4" />
-            <FormInputSelect id="type" label="Jenis Insiden" placeholder="Pilih jenis insiden" items={incidentTypeOptions} value={data.type} onValueChange={val => onUpdate({ type: val })} containerClassName="grid grid-cols-1 md:grid-cols-form-label-full gap-x-4" />
-            <FormInputText id="incidentSubject" label="Insiden mengenai" placeholder="Contoh: Pasien, Keluarga Pasien, Pengunjung" value={data.incidentSubject} onChange={e => onUpdate({ incidentSubject: e.target.value })} />
-            <FormInputSelect id="incidentLocation" label="Lokasi Insiden" placeholder="Pilih lokasi insiden" items={incidentLocationOptions} value={data.incidentLocation} onValueChange={val => onUpdate({ incidentLocation: val })} />
-            <FormInputSelect id="relatedUnit" label="Unit Terkait Insiden" placeholder="Pilih unit" items={unitOptions} value={data.relatedUnit} onValueChange={val => onUpdate({ relatedUnit: val })} />
+            <FormInputTextarea id="chronology" label="Kronologis Insiden" placeholder="Jelaskan secara singkat bagaimana insiden terjadi." value={data.chronology ?? ""} onChange={e => onUpdate({ chronology: e.target.value })} containerClassName="grid grid-cols-1 md:grid-cols-form-label-full gap-x-4" />
+            <FormInputSelect id="type" label="Jenis Insiden" placeholder="Pilih jenis insiden" items={incidentTypeOptions} value={data.type ?? ""} onValueChange={val => onUpdate({ type: val })} containerClassName="grid grid-cols-1 md:grid-cols-form-label-full gap-x-4" />
+            <FormInputText id="incidentSubject" label="Insiden mengenai" placeholder="Contoh: Pasien, Keluarga Pasien, Pengunjung" value={data.incidentSubject ?? ""} onChange={e => onUpdate({ incidentSubject: e.target.value })} />
+            <FormInputSelect id="incidentLocation" label="Lokasi Insiden" placeholder="Pilih lokasi insiden" items={incidentLocationOptions} value={data.incidentLocation ?? ""} onValueChange={val => onUpdate({ incidentLocation: val })} />
+            <FormInputSelect id="relatedUnit" label="Unit Terkait Insiden" placeholder="Pilih unit" items={unitOptions} value={data.relatedUnit ?? ""} onValueChange={val => onUpdate({ relatedUnit: val })} />
         </div>
     )
 }

--- a/src/components/organisms/incident-report-form/step3-follow-up.tsx
+++ b/src/components/organisms/incident-report-form/step3-follow-up.tsx
@@ -43,20 +43,20 @@ export function Step3FollowUp({ data, onUpdate }: StepProps) {
     return (
         <div className="space-y-6">
             <SectionTitle>Tindak Lanjut & Dampak</SectionTitle>
-            <FormInputTextarea id="firstAction" label="Tindakan yang dilakukan segera setelah kejadian" placeholder="Jelaskan tindakan pertama yang diberikan" value={data.firstAction} onChange={e => onUpdate({ firstAction: e.target.value })} containerClassName="grid grid-cols-1 md:grid-cols-form-label-full gap-x-4" />
-            <FormInputRadio id="firstActionBy" label="Tindakan dilakukan oleh" items={firstActionByOptions} value={data.firstActionBy} onValueChange={val => onUpdate({ firstActionBy: val })} />
-            <FormInputRadio id="patientImpact" label="Akibat Insiden Terhadap Pasien" items={patientImpactOptions} orientation="vertical" value={data.patientImpact} onValueChange={val => onUpdate({ patientImpact: val })} />
+              <FormInputTextarea id="firstAction" label="Tindakan yang dilakukan segera setelah kejadian" placeholder="Jelaskan tindakan pertama yang diberikan" value={data.firstAction ?? ""} onChange={e => onUpdate({ firstAction: e.target.value })} containerClassName="grid grid-cols-1 md:grid-cols-form-label-full gap-x-4" />
+              <FormInputRadio id="firstActionBy" label="Tindakan dilakukan oleh" items={firstActionByOptions} value={data.firstActionBy ?? ""} onValueChange={val => onUpdate({ firstActionBy: val })} />
+              <FormInputRadio id="patientImpact" label="Akibat Insiden Terhadap Pasien" items={patientImpactOptions} orientation="vertical" value={data.patientImpact ?? ""} onValueChange={val => onUpdate({ patientImpact: val })} />
             <Separator />
             <SectionTitle>Analisis & Pelaporan</SectionTitle>
-            <FormInputRadio id="hasHappenedBefore" label="Apakah kejadian sama pernah terjadi di unit lain?" items={hasHappenedOptions} value={data.hasHappenedBefore} onValueChange={val => onUpdate({ hasHappenedBefore: val })} />
-             <FormInputRadio id="severity" label="Grading Risiko Kejadian" items={severityOptions} orientation="vertical" value={data.severity} onValueChange={val => onUpdate({ severity: val })} />
+              <FormInputRadio id="hasHappenedBefore" label="Apakah kejadian sama pernah terjadi di unit lain?" items={hasHappenedOptions} value={data.hasHappenedBefore ?? ""} onValueChange={val => onUpdate({ hasHappenedBefore: val })} />
+              <FormInputRadio id="severity" label="Grading Risiko Kejadian" items={severityOptions} orientation="vertical" value={data.severity ?? ""} onValueChange={val => onUpdate({ severity: val })} />
             
             {canAnalyze && (
                 <>
                     <Separator />
                     <SectionTitle>Analisis & Rencana Tindak Lanjut (Diisi oleh Komite)</SectionTitle>
-                     <FormInputTextarea id="analysisNotes" label="Catatan Analisis" placeholder="Jelaskan analisis akar masalah dari insiden ini." value={data.analysisNotes} onChange={e => onUpdate({ analysisNotes: e.target.value })} containerClassName="grid grid-cols-1 md:grid-cols-form-label-full gap-x-4" />
-                    <FormInputTextarea id="followUpPlan" label="Rencana Tindak Lanjut" placeholder="Jelaskan rencana tindak lanjut untuk mencegah kejadian serupa di masa depan." value={data.followUpPlan} onChange={e => onUpdate({ followUpPlan: e.target.value })} containerClassName="grid grid-cols-1 md:grid-cols-form-label-full gap-x-4" />
+                      <FormInputTextarea id="analysisNotes" label="Catatan Analisis" placeholder="Jelaskan analisis akar masalah dari insiden ini." value={data.analysisNotes ?? ""} onChange={e => onUpdate({ analysisNotes: e.target.value })} containerClassName="grid grid-cols-1 md:grid-cols-form-label-full gap-x-4" />
+                      <FormInputTextarea id="followUpPlan" label="Rencana Tindak Lanjut" placeholder="Jelaskan rencana tindak lanjut untuk mencegah kejadian serupa di masa depan." value={data.followUpPlan ?? ""} onChange={e => onUpdate({ followUpPlan: e.target.value })} containerClassName="grid grid-cols-1 md:grid-cols-form-label-full gap-x-4" />
                 </>
             )}
 

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -4,3 +4,16 @@ import { twMerge } from "tailwind-merge"
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
+
+export function formatChronology(text: string) {
+  return text
+    .split(/\r?\n/)
+    .map((line) => {
+      const trimmed = line.trim()
+      if (!trimmed) return ""
+      const capitalized = trimmed.charAt(0).toUpperCase() + trimmed.slice(1)
+      return capitalized.endsWith(".") ? capitalized : capitalized + "."
+    })
+    .filter(Boolean)
+    .join("\n")
+}

--- a/src/store/incident-store.ts
+++ b/src/store/incident-store.ts
@@ -60,8 +60,10 @@ export const useIncidentStore = create<IncidentState>((set) => ({
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify(incident),
     })
-    if (!res.ok) throw new Error("Failed to add incident")
-    const data = await res.json()
+    const data = await res.json().catch(() => null)
+    if (!res.ok) {
+      throw new Error(data?.error || "Failed to add incident")
+    }
     set((state) => ({ incidents: [data.incident, ...state.incidents] }))
     return data.incident.id
   },

--- a/src/store/indicator-store.ts
+++ b/src/store/indicator-store.ts
@@ -144,8 +144,10 @@ export const useIndicatorStore = create<IndicatorState>((set, get) => ({
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify(payload),
     })
-    if (!res.ok) throw new Error("Failed to add indicator")
-    const data = await res.json()
+    const data = await res.json().catch(() => null)
+    if (!res.ok) {
+      throw new Error(data?.error || "Failed to add indicator")
+    }
     const base = { ...indicator, id: data.indicator.id }
     const newIndicator: Indicator = {
       ...base,


### PR DESCRIPTION
## Summary
- Add Prisma-based API routes for incidents with authentication
- Format chronology descriptions for readability and apply in incident details

## Testing
- `npm run lint`
- `npm run typecheck` *(fails: Cannot find module '@prisma/client' and numerous TS errors)*

------
https://chatgpt.com/codex/tasks/task_b_68abde1cc70c8325a657566a0c41df4c