### PR TITLE
feat: style severity badges

### DIFF
--- a/src/components/organisms/incident-table.tsx
+++ b/src/components/organisms/incident-table.tsx
@@ -84,13 +84,13 @@ export function IncidentTable({ incidents, onExport }: IncidentTableProps) {
             kuning: "KUNING (Tinggi)",
             merah: "MERAH (Sangat Tinggi)",
         }
-        const variantMap: Record<Incident['severity'], "default" | "secondary" | "destructive" | "outline"> = {
-            biru: "secondary",
-            hijau: "default",
-            kuning: "outline",
-            merah: "destructive"
+        const colorMap: Record<Incident['severity'], string> = {
+            biru: "bg-blue-500 text-white border-blue-500 hover:bg-blue-500/80",
+            hijau: "bg-green-500 text-white border-green-500 hover:bg-green-500/80",
+            kuning: "bg-yellow-500 text-yellow-900 border-yellow-500 hover:bg-yellow-500/80",
+            merah: "bg-red-500 text-white border-red-500 hover:bg-red-500/80",
         }
-        return <Badge variant={variantMap[severity]}>{severityMap[severity]}</Badge>
+        return <Badge variant="outline" className={colorMap[severity]}>{severityMap[severity]}</Badge>
       },
     },
     {


### PR DESCRIPTION
## Summary
- color-code incident severity badges with matching backgrounds

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`
- `npm run typecheck` (fails: Cannot find module '@prisma/client')

------
https://chatgpt.com/codex/tasks/task_b_68abec46b65c83259e245c830b95bba0