### PR TITLE
feat: add incident dashboard

### DIFF
--- a/src/app/dashboard/incidents/page.tsx
+++ b/src/app/dashboard/incidents/page.tsx
@@ -1,8 +1,13 @@
-
 "use client"
 
 import * as React from "react"
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card"
 import { IncidentReportDialog } from "@/components/organisms/incident-report-dialog"
 import { IncidentTable } from "@/components/organisms/incident-table"
 import { useIncidentStore } from "@/store/incident-store"
@@ -12,75 +17,188 @@ import { useUserStore } from "@/store/user-store.tsx"
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert"
 import { PlusCircle, ShieldAlert } from "lucide-react"
 import { Button } from "@/components/ui/button"
+import {
+  ResponsiveContainer,
+  LineChart,
+  Line,
+  CartesianGrid,
+  XAxis,
+  YAxis,
+  Tooltip as RechartsTooltip,
+  Legend,
+} from "recharts"
+import { format } from "date-fns"
 
 export default function IncidentsPage() {
   const { currentUser } = useUserStore()
   const incidents = useIncidentStore((state) => state.incidents)
   const fetchIncidents = useIncidentStore((state) => state.fetchIncidents)
   const [reportData, setReportData] = React.useState<any[] | null>(null)
-  const [reportColumns, setReportColumns] = React.useState<ColumnDef<any>[] | null>(null)
-  const [isNewDialogOpen, setIsNewDialogOpen] = React.useState(false);
+  const [reportColumns, setReportColumns] = React.useState<
+    ColumnDef<any>[] | null
+  >(null)
+  const [isNewDialogOpen, setIsNewDialogOpen] = React.useState(false)
 
   React.useEffect(() => {
     fetchIncidents()
   }, [fetchIncidents])
 
   const handleExport = (data: any[], columns: ColumnDef<any>[]) => {
-    setReportData(data);
-    setReportColumns(columns);
-  };
-  
-  const canViewIncidents = currentUser?.role === 'Sub. Komite Keselamatan Pasien' || currentUser?.role === 'Admin Sistem';
+    setReportData(data)
+    setReportColumns(columns)
+  }
+
+  const dashboardRoles = [
+    "Direktur",
+    "Admin Sistem",
+    "Sub. Komite Peningkatan Mutu",
+    "Sub. Komite Keselamatan Pasien",
+    "Sub. Komite Manajemen Risiko",
+  ]
+
+  const canViewDashboard = dashboardRoles.includes(currentUser?.role || "")
+
+  const canViewIncidents =
+    currentUser?.role === "Sub. Komite Keselamatan Pasien" ||
+    currentUser?.role === "Admin Sistem"
+
+  const incidentChartData = React.useMemo(() => {
+    const counts: Record<string, any> = {}
+    incidents.forEach((inc) => {
+      const date = new Date(inc.date)
+      if (isNaN(date.getTime())) return
+      const key = format(date, "yyyy-MM")
+      if (!counts[key]) {
+        counts[key] = {
+          month: format(date, "MMM yyyy"),
+          KPC: 0,
+          KNC: 0,
+          KTC: 0,
+          KTD: 0,
+          Sentinel: 0,
+        }
+      }
+      counts[key][inc.type] += 1
+    })
+    return Object.keys(counts)
+      .sort()
+      .map((key) => counts[key])
+  }, [incidents])
 
   const AddNewButton = () => (
     <Button size="lg" onClick={() => setIsNewDialogOpen(true)}>
-        <PlusCircle className="mr-2 h-5 w-5" />
-        Laporkan Insiden Baru
+      <PlusCircle className="mr-2 h-5 w-5" />
+      Laporkan Insiden Baru
     </Button>
-  );
+  )
 
   return (
-    <div className="flex-1 space-y-4 p-4 md:p-8 pt-6">
+    <div className="flex-1 space-y-4 p-4 pt-6 md:p-8">
       <div className="flex items-center justify-between space-y-2">
-        <h2 className="text-3xl font-bold tracking-tight">Manajemen Insiden Keselamatan</h2>
+        <h2 className="text-3xl font-bold tracking-tight">
+          Manajemen Insiden Keselamatan
+        </h2>
         {!canViewIncidents && <AddNewButton />}
       </div>
-      
+
+      {canViewDashboard && (
+        <Card>
+          <CardHeader>
+            <CardTitle>Dashboard Insiden</CardTitle>
+            <CardDescription>
+              Jumlah insiden per bulan berdasarkan jenis.
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <div style={{ width: "100%", height: 300 }}>
+              <ResponsiveContainer width="100%" height="100%">
+                <LineChart data={incidentChartData}>
+                  <CartesianGrid strokeDasharray="3 3" />
+                  <XAxis dataKey="month" />
+                  <YAxis allowDecimals={false} />
+                  <RechartsTooltip />
+                  <Legend />
+                  <Line
+                    type="monotone"
+                    dataKey="KPC"
+                    stroke="#8884d8"
+                    strokeWidth={2}
+                  />
+                  <Line
+                    type="monotone"
+                    dataKey="KNC"
+                    stroke="#82ca9d"
+                    strokeWidth={2}
+                  />
+                  <Line
+                    type="monotone"
+                    dataKey="KTC"
+                    stroke="#ffc658"
+                    strokeWidth={2}
+                  />
+                  <Line
+                    type="monotone"
+                    dataKey="KTD"
+                    stroke="#ff7300"
+                    strokeWidth={2}
+                  />
+                  <Line
+                    type="monotone"
+                    dataKey="Sentinel"
+                    stroke="#888888"
+                    strokeWidth={2}
+                  />
+                </LineChart>
+              </ResponsiveContainer>
+            </div>
+          </CardContent>
+        </Card>
+      )}
+
       {canViewIncidents ? (
         <>
-            <Card>
-                <CardHeader>
-                <div className="flex items-center justify-between">
-                    <div>
-                    <CardTitle>Laporan Insiden</CardTitle>
-                    <CardDescription>Daftar insiden keselamatan yang dilaporkan.</CardDescription>
-                    </div>
-                    <AddNewButton />
+          <Card>
+            <CardHeader>
+              <div className="flex items-center justify-between">
+                <div>
+                  <CardTitle>Laporan Insiden</CardTitle>
+                  <CardDescription>
+                    Daftar insiden keselamatan yang dilaporkan.
+                  </CardDescription>
                 </div>
-                </CardHeader>
-                <CardContent>
-                <IncidentTable incidents={incidents} onExport={handleExport} />
-                </CardContent>
-            </Card>
+                <AddNewButton />
+              </div>
+            </CardHeader>
+            <CardContent>
+              <IncidentTable incidents={incidents} onExport={handleExport} />
+            </CardContent>
+          </Card>
         </>
       ) : (
         <Card>
-            <CardHeader>
-                <CardTitle>Pelaporan Insiden</CardTitle>
-                <CardDescription>Gunakan tombol di pojok kanan atas untuk melaporkan insiden baru secara anonim.</CardDescription>
-            </CardHeader>
-            <CardContent>
-                <Alert>
-                    <ShieldAlert className="h-4 w-4" />
-                    <AlertTitle>Akses Terbatas</AlertTitle>
-                    <AlertDescription>
-                        Hanya Sub. Komite Keselamatan Pasien yang dapat melihat daftar laporan insiden untuk menjaga kerahasiaan data.
-                    </AlertDescription>
-                </Alert>
-            </CardContent>
+          <CardHeader>
+            <CardTitle>Pelaporan Insiden</CardTitle>
+            <CardDescription>
+              Gunakan tombol di pojok kanan atas untuk melaporkan insiden baru
+              secara anonim.
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <Alert>
+              <ShieldAlert className="h-4 w-4" />
+              <AlertTitle>Akses Terbatas</AlertTitle>
+              <AlertDescription>
+                Hanya Sub. Komite Keselamatan Pasien yang dapat melihat daftar
+                laporan insiden untuk menjaga kerahasiaan data.
+              </AlertDescription>
+            </Alert>
+          </CardContent>
         </Card>
       )}
-       <IncidentReportDialog open={isNewDialogOpen} onOpenChange={setIsNewDialogOpen} />
+      <IncidentReportDialog
+        open={isNewDialogOpen}
+        onOpenChange={setIsNewDialogOpen}
+      />
     </div>
   )
 }

--- a/src/components/organisms/incident-filter-card.tsx
+++ b/src/components/organisms/incident-filter-card.tsx
@@ -33,6 +33,10 @@ import type { FilterType } from "@/lib/indicator-utils"
 type IncidentFilterCardProps = {
   selectedType: string
   setSelectedType: (type: string) => void
+  selectedRiskType: string
+  setSelectedRiskType: (type: string) => void
+  selectedRiskLevel: string
+  setSelectedRiskLevel: (level: string) => void
   filterType: FilterType
   setFilterType: (type: FilterType) => void
   selectedDate: Date
@@ -42,10 +46,23 @@ type IncidentFilterCardProps = {
 }
 
 const INCIDENT_TYPES = ["Semua", "KPC", "KNC", "KTC", "KTD", "Sentinel"]
+const RISK_TYPES = [
+  "Semua",
+  "Kematian",
+  "Cedera ireversibel / Cedera Berat",
+  "Cedera reversibel / Cedera Sedang",
+  "Cedera Ringan",
+  "Tidak ada cedera",
+]
+const RISK_LEVELS = ["Semua", "biru", "hijau", "kuning", "merah"]
 
 export function IncidentFilterCard({
   selectedType,
   setSelectedType,
+  selectedRiskType,
+  setSelectedRiskType,
+  selectedRiskLevel,
+  setSelectedRiskLevel,
   filterType,
   setFilterType,
   selectedDate,
@@ -168,7 +185,7 @@ export function IncidentFilterCard({
         </CardDescription>
       </CardHeader>
       <CardContent className="space-y-6">
-        <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
           <div className="space-y-2">
             <Label>Jenis Insiden</Label>
             <Select value={selectedType} onValueChange={setSelectedType}>
@@ -179,6 +196,44 @@ export function IncidentFilterCard({
                 {INCIDENT_TYPES.map((t) => (
                   <SelectItem key={t} value={t}>
                     {t}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+          <div className="space-y-2">
+            <Label>Jenis Risiko</Label>
+            <Select value={selectedRiskType} onValueChange={setSelectedRiskType}>
+              <SelectTrigger className="w-full">
+                <SelectValue placeholder="Pilih jenis risiko" />
+              </SelectTrigger>
+              <SelectContent>
+                {RISK_TYPES.map((t) => (
+                  <SelectItem key={t} value={t}>
+                    {t}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+          <div className="space-y-2">
+            <Label>Tingkat Risiko</Label>
+            <Select value={selectedRiskLevel} onValueChange={setSelectedRiskLevel}>
+              <SelectTrigger className="w-full">
+                <SelectValue placeholder="Pilih tingkat risiko" />
+              </SelectTrigger>
+              <SelectContent>
+                {RISK_LEVELS.map((l) => (
+                  <SelectItem key={l} value={l}>
+                    {l === "biru"
+                      ? "BIRU (Rendah)"
+                      : l === "hijau"
+                      ? "HIJAU (Sedang)"
+                      : l === "kuning"
+                      ? "KUNING (Tinggi)"
+                      : l === "merah"
+                      ? "MERAH (Sangat Tinggi)"
+                      : l}
                   </SelectItem>
                 ))}
               </SelectContent>
@@ -224,15 +279,13 @@ export function IncidentFilterCard({
               </div>
             </div>
           </div>
-          <div className="space-y-2">
-            {showCustomFilterInput && (
-              <>
-                <Label>Filter Kustom</Label>
-                <div>{renderFilterInput()}</div>
-              </>
-            )}
-          </div>
         </div>
+        {showCustomFilterInput && (
+          <div className="space-y-2">
+            <Label>Filter Kustom</Label>
+            <div>{renderFilterInput()}</div>
+          </div>
+        )}
       </CardContent>
     </Card>
   )

--- a/src/components/organisms/incident-filter-card.tsx
+++ b/src/components/organisms/incident-filter-card.tsx
@@ -1,0 +1,240 @@
+"use client"
+
+import * as React from "react"
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import { Button } from "@/components/ui/button"
+import { Label } from "@/components/ui/label"
+import {
+  Filter as FilterIcon,
+  Calendar as CalendarIcon,
+  LineChart as LineChartIcon,
+  BarChart as BarChartIcon,
+} from "lucide-react"
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover"
+import { Calendar } from "@/components/ui/calendar"
+import { format } from "date-fns"
+import { id as IndonesianLocale } from "date-fns/locale"
+import { cn } from "@/lib/utils"
+import type { FilterType } from "@/lib/indicator-utils"
+
+type IncidentFilterCardProps = {
+  selectedType: string
+  setSelectedType: (type: string) => void
+  filterType: FilterType
+  setFilterType: (type: FilterType) => void
+  selectedDate: Date
+  setSelectedDate: (date: Date) => void
+  chartType: "line" | "bar"
+  setChartType: (type: "line" | "bar") => void
+}
+
+const INCIDENT_TYPES = ["Semua", "KPC", "KNC", "KTC", "KTD", "Sentinel"]
+
+export function IncidentFilterCard({
+  selectedType,
+  setSelectedType,
+  filterType,
+  setFilterType,
+  selectedDate,
+  setSelectedDate,
+  chartType,
+  setChartType,
+}: IncidentFilterCardProps) {
+  const renderFilterInput = () => {
+    const currentYear = new Date().getFullYear()
+    const years = Array.from({ length: 5 }, (_, i) => currentYear - i)
+    const months = Array.from({ length: 12 }, (_, i) => ({
+      value: i,
+      label: format(new Date(currentYear, i), "MMMM", { locale: IndonesianLocale }),
+    }))
+
+    if (filterType === "daily") {
+      return (
+        <Popover>
+          <PopoverTrigger asChild>
+            <Button
+              variant={"outline"}
+              className={cn(
+                "w-[200px] justify-start text-left font-normal",
+                !selectedDate && "text-muted-foreground"
+              )}
+            >
+              <CalendarIcon className="mr-2 h-4 w-4" />
+              {selectedDate
+                ? format(selectedDate, "PPP", { locale: IndonesianLocale })
+                : <span>Pilih tanggal</span>}
+            </Button>
+          </PopoverTrigger>
+          <PopoverContent className="w-auto p-0">
+            <Calendar
+              mode="single"
+              selected={selectedDate}
+              onSelect={(date) => date && setSelectedDate(date)}
+              initialFocus
+              disabled={{ after: new Date() }}
+            />
+          </PopoverContent>
+        </Popover>
+      )
+    }
+    if (filterType === "monthly") {
+      return (
+        <div className="flex gap-2">
+          <Select
+            value={selectedDate.getMonth().toString()}
+            onValueChange={(v) =>
+              setSelectedDate(new Date(selectedDate.getFullYear(), parseInt(v)))
+            }
+          >
+            <SelectTrigger className="w-[150px]">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {months.map((m) => (
+                <SelectItem key={m.value} value={m.value.toString()}>
+                  {m.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          <Select
+            value={selectedDate.getFullYear().toString()}
+            onValueChange={(v) =>
+              setSelectedDate(new Date(parseInt(v), selectedDate.getMonth()))
+            }
+          >
+            <SelectTrigger className="w-[100px]">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {years.map((y) => (
+                <SelectItem key={y} value={y.toString()}>
+                  {y}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+      )
+    }
+    if (filterType === "yearly") {
+      return (
+        <Select
+          value={selectedDate.getFullYear().toString()}
+          onValueChange={(v) =>
+            setSelectedDate(new Date(parseInt(v), selectedDate.getMonth()))
+          }
+        >
+          <SelectTrigger className="w-[150px]">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            {years.map((y) => (
+              <SelectItem key={y} value={y.toString()}>
+                {y}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      )
+    }
+    return null
+  }
+
+  const showCustomFilterInput = ["daily", "monthly", "yearly"].includes(filterType)
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>
+          <FilterIcon className="mr-2 h-5 w-5 inline-block" />
+          Filter & Tampilan Data
+        </CardTitle>
+        <CardDescription>
+          Gunakan filter di bawah untuk menampilkan data yang lebih spesifik.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-6">
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+          <div className="space-y-2">
+            <Label>Jenis Insiden</Label>
+            <Select value={selectedType} onValueChange={setSelectedType}>
+              <SelectTrigger className="w-full">
+                <SelectValue placeholder="Pilih jenis" />
+              </SelectTrigger>
+              <SelectContent>
+                {INCIDENT_TYPES.map((t) => (
+                  <SelectItem key={t} value={t}>
+                    {t}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+          <div className="space-y-2">
+            <Label>Tampilan & Rentang Waktu</Label>
+            <div className="flex flex-col sm:flex-row gap-2">
+              <div className="flex-grow">
+                <Select value={filterType} onValueChange={(v) => setFilterType(v as FilterType)}>
+                  <SelectTrigger>
+                    <SelectValue placeholder="Pilih rentang..." />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="7d">7 Hari Terakhir</SelectItem>
+                    <SelectItem value="30d">30 Hari Terakhir</SelectItem>
+                    <SelectItem value="3m">3 Bulan Terakhir</SelectItem>
+                    <SelectItem value="1y">1 Tahun Terakhir</SelectItem>
+                    <SelectItem value="3y">3 Tahun Terakhir</SelectItem>
+                    <SelectItem value="daily">Harian (Custom)</SelectItem>
+                    <SelectItem value="monthly">Bulanan (Custom)</SelectItem>
+                    <SelectItem value="yearly">Tahunan (Custom)</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+              <div className="flex items-center rounded-md border p-1 w-fit self-end">
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  onClick={() => setChartType("line")}
+                  className={cn("h-8 w-8", chartType === "line" && "bg-muted")}
+                >
+                  <LineChartIcon className="h-4 w-4" />
+                </Button>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  onClick={() => setChartType("bar")}
+                  className={cn("h-8 w-8", chartType === "bar" && "bg-muted")}
+                >
+                  <BarChartIcon className="h-4 w-4" />
+                </Button>
+              </div>
+            </div>
+          </div>
+          <div className="space-y-2">
+            {showCustomFilterInput && (
+              <>
+                <Label>Filter Kustom</Label>
+                <div>{renderFilterInput()}</div>
+              </>
+            )}
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  )
+}
+

--- a/src/components/organisms/incident-table.tsx
+++ b/src/components/organisms/incident-table.tsx
@@ -34,11 +34,13 @@ import { ReportPreviewDialog } from "./report-preview-dialog"
 import { IncidentAnalysisTable } from "./incident-analysis-table"
 
 type IncidentTableProps = {
-  incidents: Incident[];
-  onExport: (data: Incident[], columns: ColumnDef<Incident>[]) => void;
+  incidents: Incident[]
+  lineChart?: React.ReactNode
+  barChart?: React.ReactNode
+  chartDescription?: string
 }
 
-export function IncidentTable({ incidents, onExport }: IncidentTableProps) {
+export function IncidentTable({ incidents, lineChart, barChart, chartDescription }: IncidentTableProps) {
   const [sorting, setSorting] = React.useState<SortingState>([])
   const [columnFilters, setColumnFilters] = React.useState<ColumnFiltersState>([])
   const [selectedIncident, setSelectedIncident] = React.useState<Incident | null>(null);
@@ -124,10 +126,10 @@ export function IncidentTable({ incidents, onExport }: IncidentTableProps) {
   })
   
   const handleExport = (data: Incident[], columns: ColumnDef<Incident>[]) => {
-    setReportData(data);
-    setReportColumns(columns);
-    setIsPreviewOpen(true);
-  };
+    setReportData(data)
+    setReportColumns(columns)
+    setIsPreviewOpen(true)
+  }
 
 
   return (
@@ -141,7 +143,16 @@ export function IncidentTable({ incidents, onExport }: IncidentTableProps) {
           }
           className="max-w-sm"
         />
-        <Button variant="outline" className="ml-auto" onClick={() => handleExport(table.getFilteredRowModel().rows.map(row => row.original), columns.filter(c => c.id !== 'actions'))}>
+        <Button
+          variant="outline"
+          className="ml-auto"
+          onClick={() =>
+            handleExport(
+              table.getFilteredRowModel().rows.map((row) => row.original),
+              columns.filter((c) => c.id !== "actions")
+            )
+          }
+        >
             <Download className="mr-2 h-4 w-4" />
             Unduh Laporan
         </Button>
@@ -199,6 +210,9 @@ export function IncidentTable({ incidents, onExport }: IncidentTableProps) {
           data={reportData || []}
           columns={reportColumns || []}
           title="Laporan Insiden Keselamatan"
+          lineChart={lineChart}
+          barChart={barChart}
+          chartDescription={chartDescription}
           analysisTable={<IncidentAnalysisTable data={reportData || []} />}
       />
     </div>

--- a/src/hooks/use-indicator-data.ts
+++ b/src/hooks/use-indicator-data.ts
@@ -62,7 +62,7 @@ export function useIndicatorData({ allIndicators, selectedUnit, selectedIndicato
     const getGroupKey = (date: Date) => {
       if (filterType === "daily") return format(date, "HH:00")
       if (["monthly", "7d", "30d", "this_month"].includes(filterType)) return format(date, "yyyy-MM-dd")
-      if (["yearly", "3m", "6m", "1y"].includes(filterType)) return format(date, "yyyy-MM")
+      if (["yearly", "3m", "6m", "1y", "3y"].includes(filterType)) return format(date, "yyyy-MM")
       return format(date, "yyyy-MM-dd")
     }
 
@@ -89,7 +89,7 @@ export function useIndicatorData({ allIndicators, selectedUnit, selectedIndicato
         ...d,
         Capaian: parseFloat((d.Capaian / d.count).toFixed(1)),
         name: ["daily"].includes(filterType) ? format(d.date, "HH:mm")
-            : ["yearly", "3m", "6m", "1y"].includes(filterType) ? format(d.date, "MMM", { locale: IndonesianLocale })
+            : ["yearly", "3m", "6m", "1y", "3y"].includes(filterType) ? format(d.date, "MMM", { locale: IndonesianLocale })
             : format(d.date, "dd MMM"),
       }))
       .sort((a, b) => a.date.getTime() - b.date.getTime())

--- a/src/lib/indicator-utils.ts
+++ b/src/lib/indicator-utils.ts
@@ -21,6 +21,7 @@ export type FilterType =
   | "3m"
   | "6m"
   | "1y"
+  | "3y"
 
 export const calculateRatio = (
   indicator: Omit<Indicator, "id" | "ratio" | "status">
@@ -81,6 +82,8 @@ export const getFilterRange = (
       return { start: subMonths(now, 6), end: now }
     case "1y":
       return { start: subMonths(now, 12), end: now }
+    case "3y":
+      return { start: subMonths(now, 36), end: now }
     default:
       return { start: startOfMonth(now), end: endOfMonth(now) }
   }
@@ -115,6 +118,8 @@ export const getFilterDescription = (
       return `Menampilkan data untuk 6 Bulan Terakhir (${formatDateRange(start, end)}).`
     case "1y":
       return `Menampilkan data untuk 1 Tahun Terakhir (${formatDateRange(start, end)}).`
+    case "3y":
+      return `Menampilkan data untuk 3 Tahun Terakhir (${formatDateRange(start, end)}).`
     default:
       return "Menampilkan data."
   }


### PR DESCRIPTION
## Summary
- add safety incident dashboard with line chart showing monthly counts per type
- restrict dashboard visibility to director, admin, and committee roles

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`
- `npm run typecheck` (fails: cannot find module '@prisma/client' etc.)

------
https://chatgpt.com/codex/tasks/task_b_68abf0237050832581b16d8fadb6e8bb