### PR TITLE
fix: include charts in printed reports and improve incident chronology

### DIFF
--- a/src/app/dashboard/incidents/page.tsx
+++ b/src/app/dashboard/incidents/page.tsx
@@ -178,6 +178,12 @@ export default function IncidentsPage() {
     </ResponsiveContainer>
   )
 
+  const noDataMessage = (
+    <p className="flex h-full items-center justify-center text-sm text-muted-foreground">
+      Tidak ada data untuk periode ini.
+    </p>
+  )
+
   const AddNewButton = () => (
     <Button size="lg" onClick={() => setIsNewDialogOpen(true)}>
       <PlusCircle className="mr-2 h-5 w-5" />
@@ -240,7 +246,9 @@ export default function IncidentsPage() {
             </CardHeader>
             <CardContent>
               <div style={{ width: "100%", height: 300 }}>
-                {chartType === "line" ? lineChart : barChart}
+                {incidentChartData.length > 0
+                  ? (chartType === "line" ? lineChart : barChart)
+                  : noDataMessage}
               </div>
             </CardContent>
           </Card>
@@ -264,9 +272,13 @@ export default function IncidentsPage() {
             <CardContent>
               <IncidentTable
                 incidents={filteredIncidents}
-                lineChart={lineChart}
-                barChart={barChart}
-                chartDescription={getFilterDescription(filterType, selectedDate)}
+                lineChart={incidentChartData.length > 0 ? lineChart : noDataMessage}
+                barChart={incidentChartData.length > 0 ? barChart : noDataMessage}
+                chartDescription={
+                  incidentChartData.length > 0
+                    ? getFilterDescription(filterType, selectedDate)
+                    : undefined
+                }
               />
             </CardContent>
           </Card>

--- a/src/app/dashboard/incidents/page.tsx
+++ b/src/app/dashboard/incidents/page.tsx
@@ -149,33 +149,37 @@ export default function IncidentsPage() {
   const typesToShow = selectedType === "Semua" ? Object.keys(colorMap) : [selectedType]
 
   const lineChart = (
-    <ResponsiveContainer width="100%" height="100%">
-      <LineChart data={incidentChartData}>
-        <CartesianGrid strokeDasharray="3 3" />
-        <XAxis dataKey="period" />
-        <YAxis allowDecimals={false} />
-        <RechartsTooltip />
-        <Legend />
-        {typesToShow.map((t) => (
-          <Line key={t} type="monotone" dataKey={t} stroke={colorMap[t]} strokeWidth={2} />
-        ))}
-      </LineChart>
-    </ResponsiveContainer>
+    <div style={{ width: "100%", height: 350 }}>
+      <ResponsiveContainer width="100%" height="100%">
+        <LineChart data={incidentChartData}>
+          <CartesianGrid strokeDasharray="3 3" />
+          <XAxis dataKey="period" />
+          <YAxis allowDecimals={false} />
+          <RechartsTooltip />
+          <Legend />
+          {typesToShow.map((t) => (
+            <Line key={t} type="monotone" dataKey={t} stroke={colorMap[t]} strokeWidth={2} />
+          ))}
+        </LineChart>
+      </ResponsiveContainer>
+    </div>
   )
 
   const barChart = (
-    <ResponsiveContainer width="100%" height="100%">
-      <BarChart data={incidentChartData}>
-        <CartesianGrid strokeDasharray="3 3" />
-        <XAxis dataKey="period" />
-        <YAxis allowDecimals={false} />
-        <RechartsTooltip />
-        <Legend />
-        {typesToShow.map((t) => (
-          <Bar key={t} dataKey={t} fill={colorMap[t]} />
-        ))}
-      </BarChart>
-    </ResponsiveContainer>
+    <div style={{ width: "100%", height: 350 }}>
+      <ResponsiveContainer width="100%" height="100%">
+        <BarChart data={incidentChartData}>
+          <CartesianGrid strokeDasharray="3 3" />
+          <XAxis dataKey="period" />
+          <YAxis allowDecimals={false} />
+          <RechartsTooltip />
+          <Legend />
+          {typesToShow.map((t) => (
+            <Bar key={t} dataKey={t} fill={colorMap[t]} />
+          ))}
+        </BarChart>
+      </ResponsiveContainer>
+    </div>
   )
 
   const noDataMessage = (

--- a/src/components/organisms/incident-detail-dialog.tsx
+++ b/src/components/organisms/incident-detail-dialog.tsx
@@ -25,9 +25,33 @@ const DetailItem = ({ label, value }: { label: string, value: React.ReactNode })
 const FullWidthDetailItem = ({ label, value }: { label: string, value: React.ReactNode }) => (
     <div className="md:col-span-2">
         <p className="text-muted-foreground">{label}</p>
-        <p className="font-medium whitespace-pre-wrap leading-relaxed text-justify">{value || "-"}</p>
+        {typeof value === "string" || value === undefined || value === null ? (
+            <p className="font-medium whitespace-pre-wrap leading-relaxed text-justify">{value || "-"}</p>
+        ) : (
+            value
+        )}
     </div>
 )
+
+const ChronologyList = ({ text }: { text: string }) => {
+    const steps = formatChronology(text)
+        .split("\n")
+        .filter(Boolean)
+
+    if (steps.length === 0) {
+        return <p className="font-medium">-</p>
+    }
+
+    return (
+        <ol className="list-decimal pl-6 space-y-1 text-sm">
+            {steps.map((step, index) => (
+                <li key={index} className="leading-relaxed text-justify">
+                    {step}
+                </li>
+            ))}
+        </ol>
+    )
+}
 
 type IncidentDetailDialogProps = {
     incident: Incident | null
@@ -66,7 +90,7 @@ export const IncidentDetailDialog = ({ incident, open, onOpenChange }: IncidentD
                          <DetailItem label="Insiden Mengenai" value={incident.incidentSubject} />
                          <DetailItem label="Lokasi Insiden" value={incident.incidentLocation} />
                          <DetailItem label="Unit Terkait" value={incident.relatedUnit} />
-                         <FullWidthDetailItem label="Kronologis Insiden" value={formatChronology(incident.chronology || "")} />
+                         <FullWidthDetailItem label="Kronologis Insiden" value={<ChronologyList text={incident.chronology || ""} />} />
                     </DetailSection>
                     <Separator />
                     <DetailSection title="Tindak Lanjut & Analisis">

--- a/src/components/organisms/indicator-report.tsx
+++ b/src/components/organisms/indicator-report.tsx
@@ -86,7 +86,7 @@ export function IndicatorReport({ indicators, category, title, description, show
         return null;
     };
     
-    const lineChartComponent = chartData && (
+    const lineChartComponent = chartData && chartData.length > 0 ? (
         <div style={{ width: '100%', height: 350 }}>
             <ResponsiveContainer width="100%" height="100%">
                 <LineChart data={chartData} margin={{ top: 20, right: 20, left: -10, bottom: 5 }}>
@@ -104,9 +104,11 @@ export function IndicatorReport({ indicators, category, title, description, show
                 </LineChart>
             </ResponsiveContainer>
         </div>
+    ) : (
+        <p className="text-center text-sm text-muted-foreground">Tidak ada data untuk periode ini.</p>
     )
 
-    const barChartComponent = chartData && (
+    const barChartComponent = chartData && chartData.length > 0 ? (
         <div style={{ width: '100%', height: 350 }}>
             <ResponsiveContainer width="100%" height="100%">
                 <BarChart data={chartData} margin={{ top: 20, right: 20, left: -10, bottom: 5 }}>
@@ -121,6 +123,8 @@ export function IndicatorReport({ indicators, category, title, description, show
                 </BarChart>
             </ResponsiveContainer>
         </div>
+    ) : (
+        <p className="text-center text-sm text-muted-foreground">Tidak ada data untuk periode ini.</p>
     )
 
 
@@ -173,6 +177,7 @@ export function IndicatorReport({ indicators, category, title, description, show
                 columns={reportColumns || []}
                 title={`Laporan Capaian ${title || `Indikator ${category}`}`}
                 description={reportDescription}
+                chartDescription={chartData && chartData.length > 0 ? reportDescription : undefined}
                 lineChart={lineChartComponent}
                 barChart={barChartComponent}
                 analysisTable={<AnalysisTable data={reportTableData || []} />}

--- a/src/components/organisms/report-preview-dialog.tsx
+++ b/src/components/organisms/report-preview-dialog.tsx
@@ -66,20 +66,55 @@ export function ReportPreviewDialog<TData>({
         printWindow.document.write('<style>');
         printWindow.document.write(`
           @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap');
-          body { 
-            font-family: 'Inter', sans-serif; 
-            -webkit-print-color-adjust: exact !important; 
+          :root {
+            --background: 120 10% 97%;
+            --foreground: 240 10% 3.9%;
+            --card: 0 0% 100%;
+            --card-foreground: 240 10% 3.9%;
+            --popover: 0 0% 100%;
+            --popover-foreground: 240 10% 3.9%;
+            --primary: 124 51% 71%;
+            --primary-foreground: 125 45% 15%;
+            --secondary: 120 20% 92%;
+            --secondary-foreground: 240 10% 3.9%;
+            --muted: 120 20% 92%;
+            --muted-foreground: 240 3.8% 46.1%;
+            --accent: 122 40% 82%;
+            --accent-foreground: 125 45% 15%;
+            --destructive: 0 84.2% 60.2%;
+            --destructive-foreground: 0 0% 98%;
+            --border: 120 15% 88%;
+            --input: 120 15% 88%;
+            --ring: 124 51% 71%;
+            --chart-1: 124 51% 71%;
+            --chart-2: 130 45% 65%;
+            --chart-3: 135 40% 60%;
+            --chart-4: 120 40% 75%;
+            --chart-5: 115 45% 80%;
+            --radius: 0.5rem;
+            --sidebar-background: 220 10% 15%;
+            --sidebar-foreground: 0 0% 98%;
+            --sidebar-primary: 124 51% 71%;
+            --sidebar-primary-foreground: 125 45% 15%;
+            --sidebar-accent: 220 10% 25%;
+            --sidebar-accent-foreground: 0 0% 98%;
+            --sidebar-border: 220 10% 25%;
+            --sidebar-ring: 124 51% 71%;
+          }
+          body {
+            font-family: 'Inter', sans-serif;
+            -webkit-print-color-adjust: exact !important;
             print-color-adjust: exact !important;
             color: #000;
           }
-          @page { 
-            size: landscape; 
-            margin: 20px; 
+          @page {
+            size: landscape;
+            margin: 20px;
           }
           .no-print { display: none; }
-          .print-page-break { 
-            page-break-after: always; 
-            margin-top: 2rem; 
+          .print-page-break {
+            page-break-after: always;
+            margin-top: 2rem;
             margin-bottom: 2rem;
           }
           .print-header {
@@ -91,7 +126,7 @@ export function ReportPreviewDialog<TData>({
               font-size: 1.5rem;
               font-weight: bold;
           }
-            .print-header p {
+          .print-header p {
               font-size: 0.875rem;
               color: #6B7280;
           }

--- a/src/components/organisms/report-preview-dialog.tsx
+++ b/src/components/organisms/report-preview-dialog.tsx
@@ -71,20 +71,25 @@ export function ReportPreviewDialog<TData>({
     });
 
     const contentToPrint = reportRef.current.cloneNode(true) as HTMLDivElement;
+    const serializer = new XMLSerializer();
     contentToPrint
       .querySelectorAll('.recharts-responsive-container')
       .forEach((container, idx) => {
         const { width, height } = chartSizes[idx];
-        const wrapper = container.firstElementChild as HTMLElement | null;
-        if (wrapper) {
-          wrapper.style.width = `${width}px`;
-          wrapper.style.height = `${height}px`;
-          const svg = wrapper.querySelector('svg');
-          if (svg) {
-            svg.setAttribute('width', `${width}`);
-            svg.setAttribute('height', `${height}`);
-          }
-          container.parentNode?.replaceChild(wrapper, container);
+        const svg = container.querySelector('svg');
+        if (svg) {
+          svg.setAttribute('xmlns', 'http://www.w3.org/2000/svg');
+          svg.setAttribute('width', `${width}`);
+          svg.setAttribute('height', `${height}`);
+
+          const svgString = serializer.serializeToString(svg);
+          const encoded = window.btoa(unescape(encodeURIComponent(svgString)));
+          const img = document.createElement('img');
+          img.src = `data:image/svg+xml;base64,${encoded}`;
+          img.width = width;
+          img.height = height;
+
+          container.parentNode?.replaceChild(img, container);
         }
       });
 


### PR DESCRIPTION
## Summary
- inject Tailwind CSS variables into printed reports so line and bar charts render correctly
- display incident chronologies as easy-to-read numbered lists for non-technical users

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run typecheck` *(fails: see logs)*

------
https://chatgpt.com/codex/tasks/task_b_68abf68811608325b27fe31816e7c7d6