### PR TITLE
feat: improve survey tools and add help pages

### DIFF
--- a/src/app/dashboard/faq/page.tsx
+++ b/src/app/dashboard/faq/page.tsx
@@ -1,0 +1,18 @@
+export default function FAQPage() {
+  return (
+    <div className="flex-1 space-y-4 p-4 md:p-8 pt-6">
+      <h2 className="text-3xl font-bold tracking-tight">FAQ</h2>
+      <p>Pertanyaan yang sering diajukan mengenai penggunaan sistem.</p>
+      <ul className="list-disc space-y-2 pl-4">
+        <li>
+          <strong>Bagaimana cara mengunduh laporan?</strong> Gunakan tombol
+          &quot;Unduh Laporan&quot; pada halaman terkait.
+        </li>
+        <li>
+          <strong>Siapa yang dapat mengakses dashboard?</strong> Pengguna yang
+          memiliki hak akses sesuai perannya.
+        </li>
+      </ul>
+    </div>
+  )
+}

--- a/src/app/dashboard/surveys/dashboard/page.tsx
+++ b/src/app/dashboard/surveys/dashboard/page.tsx
@@ -1,0 +1,66 @@
+"use client"
+
+import * as React from "react"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { useSurveyStore } from "@/store/survey-store"
+import {
+  ResponsiveContainer,
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  Tooltip,
+} from "recharts"
+
+export default function SurveyDashboardPage() {
+  const surveys = useSurveyStore((state) => state.surveys)
+
+  const chartData = React.useMemo(
+    () =>
+      surveys.map((s) => ({
+        unit: s.unit,
+        score: Number(s.totalScore.toFixed(2)),
+      })),
+    [surveys]
+  )
+
+  const avgScore = React.useMemo(() => {
+    if (chartData.length === 0) return 0
+    return chartData.reduce((acc, d) => acc + d.score, 0) / chartData.length
+  }, [chartData])
+
+  return (
+    <div className="flex-1 space-y-4 p-4 md:p-8 pt-6">
+      <h2 className="text-3xl font-bold tracking-tight">Dashboard Survei Budaya</h2>
+      <Card>
+        <CardHeader>
+          <CardTitle>Rata-rata Skor Per Unit</CardTitle>
+        </CardHeader>
+        <CardContent>
+          {chartData.length > 0 ? (
+            <div className="h-[300px]">
+              <ResponsiveContainer width="100%" height="100%">
+                <BarChart data={chartData}>
+                  <XAxis dataKey="unit" />
+                  <YAxis />
+                  <Tooltip />
+                  <Bar dataKey="score" fill="#8884d8" />
+                </BarChart>
+              </ResponsiveContainer>
+            </div>
+          ) : (
+            <p className="text-center text-sm text-muted-foreground">Belum ada data survei.</p>
+          )}
+        </CardContent>
+      </Card>
+      <Card>
+        <CardHeader>
+          <CardTitle>Rata-rata Skor Keseluruhan</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <p className="text-2xl font-semibold">{avgScore.toFixed(2)}</p>
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/src/app/dashboard/surveys/page.tsx
+++ b/src/app/dashboard/surveys/page.tsx
@@ -4,6 +4,13 @@ import * as React from "react"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
 import { Download, PlusCircle } from "lucide-react"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
 import { SurveyTable } from "@/components/organisms/survey-table"
 import { SurveyDialog } from "@/components/organisms/survey-dialog"
 import { ReportPreviewDialog } from "@/components/organisms/report-preview-dialog"
@@ -16,12 +23,25 @@ export default function SurveysPage() {
   const [editingSurvey, setEditingSurvey] = React.useState<SurveyResult | null>(null)
   const [isPreviewOpen, setIsPreviewOpen] = React.useState(false)
   const [csvData, setCsvData] = React.useState("")
+  const [filterUnit, setFilterUnit] = React.useState<string>("all")
 
-  const generateCSV = () => {
+  const units = React.useMemo(() => {
+    return Array.from(new Set(surveys.map((s) => s.unit)))
+  }, [surveys])
+
+  const filteredSurveys = React.useMemo(
+    () =>
+      filterUnit === "all"
+        ? surveys
+        : surveys.filter((s) => s.unit === filterUnit),
+    [surveys, filterUnit]
+  )
+
+  const generateCSV = (data: SurveyResult[]) => {
     const headers = ["ID", "Tanggal Pengisian", "Unit Kerja", "Total Skor", "Rata-rata Dimensi"];
     const csvRows = [headers.join(",")];
 
-    surveys.forEach(survey => {
+    data.forEach(survey => {
       const avgScore = Object.values(survey.scores).reduce((acc, dim) => acc + dim.score, 0) / Object.keys(survey.scores).length;
       const row = [
         survey.id,
@@ -37,22 +57,40 @@ export default function SurveysPage() {
   };
 
   const handlePreview = () => {
-    setCsvData(generateCSV());
-    setIsPreviewOpen(true);
-  };
+    setCsvData(generateCSV(filteredSurveys))
+    setIsPreviewOpen(true)
+  }
 
-  const downloadCSV = () => {
-    const blob = new Blob([csvData], { type: "text/csv" });
-    const url = URL.createObjectURL(blob);
-    const a = document.createElement("a");
-    a.setAttribute("hidden", "");
-    a.setAttribute("href", url);
-    a.setAttribute("download", `laporan_survei_keselamatan_${format(new Date(), "yyyyMMdd")}.csv`);
-    document.body.appendChild(a);
-    a.click();
-    document.body.removeChild(a);
-    setIsPreviewOpen(false);
-  };
+  const downloadXLS = () => {
+    const rows = csvData.split("\n").map((row) => row.split(","))
+    const table = `
+      <table border="1">
+        ${rows
+          .map(
+            (r) =>
+              `<tr>${r
+                .map((c) => `<td>${c}</td>`)
+                .join("")}</tr>`
+          )
+          .join("")}
+      </table>
+    `
+    const blob = new Blob([table], {
+      type: "application/vnd.ms-excel",
+    })
+    const url = URL.createObjectURL(blob)
+    const a = document.createElement("a")
+    a.setAttribute("hidden", "")
+    a.setAttribute("href", url)
+    a.setAttribute(
+      "download",
+      `laporan_survei_keselamatan_${format(new Date(), "yyyyMMdd")}.xls`
+    )
+    document.body.appendChild(a)
+    a.click()
+    document.body.removeChild(a)
+    setIsPreviewOpen(false)
+  }
 
   const handleDialogChange = (open: boolean) => {
     if (!open) {
@@ -68,31 +106,62 @@ export default function SurveysPage() {
       </div>
       <Card>
         <CardHeader>
-          <div className="flex items-center justify-between">
+          <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
             <div>
               <CardTitle>Laporan Hasil Survei</CardTitle>
               <CardDescription>
                 Daftar semua hasil survei budaya keselamatan yang telah dikirimkan.
               </CardDescription>
             </div>
-            <div className="flex items-center gap-2">
-              <Button variant="outline" size="lg" onClick={handlePreview} disabled={surveys.length === 0}>
+            <div className="flex flex-col items-start gap-2 md:flex-row md:items-center">
+              <Select value={filterUnit} onValueChange={setFilterUnit}>
+                <SelectTrigger className="w-[200px]">
+                  <SelectValue placeholder="Pilih Unit" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="all">Semua Unit</SelectItem>
+                  {units.map((u) => (
+                    <SelectItem key={u} value={u}>
+                      {u}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+              <div className="flex items-center gap-2">
+                <Button
+                  variant="outline"
+                  size="lg"
+                  onClick={handlePreview}
+                  disabled={filteredSurveys.length === 0}
+                >
                   <Download className="mr-2 h-5 w-5" />
                   Unduh Laporan
-              </Button>
-              <Button size="lg" onClick={() => setIsSurveyDialogOpen(true)}>
+                </Button>
+                <Button size="lg" onClick={() => setIsSurveyDialogOpen(true)}>
                   <PlusCircle className="mr-2 h-5 w-5" />
                   Isi Survei Baru
-              </Button>
+                </Button>
+              </div>
             </div>
           </div>
         </CardHeader>
         <CardContent>
-          <SurveyTable surveys={surveys} onEdit={(s) => { setEditingSurvey(s); setIsSurveyDialogOpen(true); }} />
+          <SurveyTable
+            surveys={filteredSurveys}
+            onEdit={(s) => {
+              setEditingSurvey(s)
+              setIsSurveyDialogOpen(true)
+            }}
+          />
         </CardContent>
       </Card>
       <SurveyDialog open={isSurveyDialogOpen} onOpenChange={handleDialogChange} survey={editingSurvey} />
-      <ReportPreviewDialog open={isPreviewOpen} onOpenChange={setIsPreviewOpen} csvData={csvData} onDownload={downloadCSV} />
+      <ReportPreviewDialog
+        open={isPreviewOpen}
+        onOpenChange={setIsPreviewOpen}
+        csvData={csvData}
+        onDownload={downloadXLS}
+      />
     </div>
   );
 }

--- a/src/app/dashboard/user-guide/page.tsx
+++ b/src/app/dashboard/user-guide/page.tsx
@@ -1,0 +1,25 @@
+export default function UserGuidePage() {
+  return (
+    <div className="flex-1 space-y-4 p-4 md:p-8 pt-6">
+      <h2 className="text-3xl font-bold tracking-tight">Panduan Pengguna</h2>
+      <p>
+        Halaman ini memberikan panduan singkat mengenai penggunaan sistem dan
+        peran yang tersedia.
+      </p>
+      <ul className="list-disc space-y-2 pl-4">
+        <li>
+          <strong>Admin:</strong> mengelola pengguna, notifikasi, dan pengaturan
+          sistem.
+        </li>
+        <li>
+          <strong>Petugas:</strong> mengisi survei, melaporkan insiden, dan
+          memantau data.
+        </li>
+        <li>
+          <strong>Pimpinan:</strong> melihat laporan dan dashboard untuk
+          pengambilan keputusan.
+        </li>
+      </ul>
+    </div>
+  )
+}

--- a/src/components/dashboard-layout-client.tsx
+++ b/src/components/dashboard-layout-client.tsx
@@ -33,6 +33,8 @@ import {
   Loader2,
   Bell,
   Cog,
+  BookOpen,
+  HelpCircle,
 } from "lucide-react";
 import Link from "next/link";
 import favicon from "@/app/favicon.ico";
@@ -99,9 +101,12 @@ const navItems: NavItemType[] = [
     icon: ClipboardCheck,
     subItems: [
       {
-        href: "/dashboard/surveys",
-        icon: ClipboardCheck,
         label: "Survei Budaya",
+        icon: ClipboardCheck,
+        subItems: [
+          { href: "/dashboard/surveys", icon: ListChecks, label: "Laporan" },
+          { href: "/dashboard/surveys/dashboard", icon: BarChart3, label: "Dashboard" },
+        ],
       },
       { href: "/dashboard/risks", icon: BarChart3, label: "Manajemen Risiko" },
     ],
@@ -117,6 +122,8 @@ const adminNavItems: NavItemType[] = [
       { href: "/dashboard/users", icon: Users, label: "Manajemen Pengguna" },
       { href: "/dashboard/logs", icon: History, label: "Log Sistem" },
       { href: "/dashboard/settings", icon: Settings, label: "Pengaturan" },
+      { href: "/dashboard/user-guide", icon: BookOpen, label: "Panduan Pengguna" },
+      { href: "/dashboard/faq", icon: HelpCircle, label: "FAQ" },
     ],
   },
 ];


### PR DESCRIPTION
## Summary
- add unit filter and XLS report export for safety culture surveys
- introduce safety culture dashboard for survey analysis
- provide user guide and FAQ pages with navigation links

## Testing
- `npm run lint`
- `npm run typecheck` *(fails: Cannot find module '@prisma/client' and other type errors)*

------
https://chatgpt.com/codex/tasks/task_b_68ac1a1c26788325b20aade36b217cee