### PR TITLE
feat: add prisma auth flow and user api

### DIFF
--- a/src/app/api/session/route.ts
+++ b/src/app/api/session/route.ts
@@ -1,0 +1,13 @@
+import { NextResponse } from "next/server"
+import { cookies } from "next/headers"
+import { prisma } from "@/lib/db"
+
+export async function GET() {
+  const cookieStore = await cookies()
+  const userId = cookieStore.get("session_user_id")?.value
+  if (!userId) {
+    return NextResponse.json({ user: null })
+  }
+  const user = await prisma.user.findUnique({ where: { id: userId } })
+  return NextResponse.json({ user })
+}

--- a/src/app/api/session/route.ts
+++ b/src/app/api/session/route.ts
@@ -2,6 +2,8 @@ import { NextResponse } from "next/server"
 import { cookies } from "next/headers"
 import { prisma } from "@/lib/db"
 
+export const runtime = 'nodejs'
+
 export async function GET() {
   const cookieStore = await cookies()
   const userId = cookieStore.get("session_user_id")?.value

--- a/src/app/api/users/route.ts
+++ b/src/app/api/users/route.ts
@@ -1,0 +1,15 @@
+import { NextResponse } from "next/server"
+import { prisma } from "@/lib/db"
+
+export async function GET() {
+  const users = await prisma.user.findMany({
+    select: {
+      id: true,
+      name: true,
+      email: true,
+      role: true,
+      unit: true,
+    },
+  })
+  return NextResponse.json({ users })
+}

--- a/src/app/api/users/route.ts
+++ b/src/app/api/users/route.ts
@@ -1,6 +1,8 @@
 import { NextResponse } from "next/server"
 import { prisma } from "@/lib/db"
 
+export const runtime = 'nodejs'
+
 export async function GET() {
   const users = await prisma.user.findMany({
     select: {

--- a/src/lib/actions/auth.ts
+++ b/src/lib/actions/auth.ts
@@ -25,3 +25,10 @@ export async function logout() {
   const cookieStore = await cookies()
   cookieStore.delete("session_user_id")
 }
+
+export async function getSession() {
+  const cookieStore = await cookies()
+  const userId = cookieStore.get("session_user_id")?.value
+  if (!userId) return null
+  return prisma.user.findUnique({ where: { id: userId } })
+}

--- a/src/lib/actions/auth.ts
+++ b/src/lib/actions/auth.ts
@@ -1,0 +1,27 @@
+"use server"
+
+import { cookies } from "next/headers"
+import { prisma } from "@/lib/db"
+
+export async function login(formData: FormData) {
+  const email = formData.get("email")?.toString()
+  const password = formData.get("password")?.toString()
+
+  if (!email || !password) {
+    throw new Error("Email dan password wajib diisi")
+  }
+
+  const user = await prisma.user.findUnique({ where: { email } })
+  if (!user || user.password !== password) {
+    throw new Error("Email atau password salah")
+  }
+
+  const cookieStore = await cookies()
+  cookieStore.set("session_user_id", user.id, { httpOnly: true })
+  return user
+}
+
+export async function logout() {
+  const cookieStore = await cookies()
+  cookieStore.delete("session_user_id")
+}

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -1,0 +1,10 @@
+import { PrismaClient } from "@prisma/client"
+
+const globalForPrisma = globalThis as unknown as {
+  prisma?: PrismaClient
+}
+
+export const prisma =
+  globalForPrisma.prisma ?? new PrismaClient({ log: ["error", "warn"] })
+
+if (process.env.NODE_ENV !== "production") globalForPrisma.prisma = prisma

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,6 +1,5 @@
 
 import { NextRequest, NextResponse } from 'next/server';
-import { getSession } from '@/lib/actions/auth';
 
 const protectedRoutes = ['/dashboard'];
 
@@ -9,8 +8,11 @@ export default async function middleware(req: NextRequest) {
   const isProtectedRoute = protectedRoutes.some((route) => path.startsWith(route));
 
   if (isProtectedRoute) {
-    const session = await getSession();
-    if (!session) {
+    const sessionRes = await fetch(new URL('/api/session', req.url), {
+      headers: { cookie: req.headers.get('cookie') ?? '' },
+    });
+    const { user } = await sessionRes.json();
+    if (!user) {
       return NextResponse.redirect(new URL('/', req.nextUrl));
     }
   }


### PR DESCRIPTION
## Summary
- add Prisma client helper
- implement login/logout actions with session cookies
- expose `/api/users` and `/api/session` endpoints

## Testing
- `npm run lint`
- `npm run typecheck` *(fails: Cannot find module '@prisma/client' and other type errors)*
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_b_68ac2f70ec748325bb9a29a0b5fbe3ab