### PR TITLE
feat: add survey dashboard with filters and charts

### DIFF
--- a/src/app/dashboard/surveys/page.tsx
+++ b/src/app/dashboard/surveys/page.tsx
@@ -9,6 +9,7 @@ import { SurveyDialog } from "@/components/organisms/survey-dialog"
 import { ReportPreviewDialog } from "@/components/organisms/report-preview-dialog"
 import { SurveyResult, useSurveyStore } from "@/store/survey-store"
 import { format } from "date-fns"
+import { SurveyDashboard } from "@/components/organisms/survey-dashboard"
 
 export default function SurveysPage() {
   const surveys = useSurveyStore((state) => state.surveys)
@@ -66,6 +67,7 @@ export default function SurveysPage() {
       <div className="flex items-center justify-between space-y-2">
         <h2 className="text-3xl font-bold tracking-tight">Survei Budaya Keselamatan</h2>
       </div>
+      <SurveyDashboard />
       <Card>
         <CardHeader>
           <div className="flex items-center justify-between">

--- a/src/components/organisms/survey-dashboard.tsx
+++ b/src/components/organisms/survey-dashboard.tsx
@@ -1,0 +1,143 @@
+"use client"
+
+import * as React from "react"
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card"
+import { SurveyFilterCard } from "@/components/organisms/survey-filter-card"
+import { useSurveyStore } from "@/store/survey-store"
+import {
+  ResponsiveContainer,
+  LineChart,
+  Line,
+  BarChart,
+  Bar,
+  CartesianGrid,
+  XAxis,
+  YAxis,
+  Tooltip as RechartsTooltip,
+} from "recharts"
+import { getFilterRange, getFilterDescription, FilterType } from "@/lib/indicator-utils"
+import { format } from "date-fns"
+
+export function SurveyDashboard() {
+  const surveys = useSurveyStore((state) => state.surveys)
+  const [selectedUnit, setSelectedUnit] = React.useState("Semua")
+  const [filterType, setFilterType] = React.useState<FilterType>("30d")
+  const [selectedDate, setSelectedDate] = React.useState(new Date())
+  const [chartType, setChartType] = React.useState<"line" | "bar">("line")
+
+  const availableUnits = React.useMemo(
+    () => Array.from(new Set(surveys.map((s) => s.unit))),
+    [surveys]
+  )
+
+  const filteredSurveys = React.useMemo(() => {
+    const { start, end } = getFilterRange(filterType, selectedDate)
+    return surveys.filter((s) => {
+      const date = new Date(s.submissionDate)
+      return (
+        date >= start &&
+        date <= end &&
+        (selectedUnit === "Semua" || s.unit === selectedUnit)
+      )
+    })
+  }, [surveys, selectedUnit, filterType, selectedDate])
+
+  const chartData = React.useMemo(() => {
+    const { start, end } = getFilterRange(filterType, selectedDate)
+    const data: Record<string, { period: string; jumlah: number }> = {}
+    const formatKey = (date: Date) => {
+      if (filterType === "daily")
+        return { key: format(date, "yyyy-MM-dd-HH"), label: format(date, "HH:mm") }
+      if (["7d", "30d", "this_month"].includes(filterType))
+        return { key: format(date, "yyyy-MM-dd"), label: format(date, "dd MMM") }
+      if (["3m", "6m", "1y"].includes(filterType))
+        return { key: format(date, "yyyy-MM"), label: format(date, "MMM yyyy") }
+      if (["yearly"].includes(filterType))
+        return { key: format(date, "yyyy"), label: format(date, "yyyy") }
+      return { key: format(date, "yyyy-MM-dd"), label: format(date, "dd MMM") }
+    }
+
+    surveys.forEach((s) => {
+      const date = new Date(s.submissionDate)
+      if (isNaN(date.getTime())) return
+      if (date < start || date > end) return
+      if (selectedUnit !== "Semua" && s.unit !== selectedUnit) return
+      const { key, label } = formatKey(date)
+      if (!data[key]) {
+        data[key] = { period: label, jumlah: 0 }
+      }
+      data[key].jumlah += 1
+    })
+
+    return Object.keys(data)
+      .sort()
+      .map((k) => data[k])
+  }, [surveys, selectedUnit, filterType, selectedDate])
+
+  const lineChart = (
+    <div style={{ width: "100%", height: 350 }}>
+      <ResponsiveContainer width="100%" height="100%">
+        <LineChart data={chartData}>
+          <CartesianGrid strokeDasharray="3 3" />
+          <XAxis dataKey="period" />
+          <YAxis allowDecimals={false} />
+          <RechartsTooltip />
+          <Line type="monotone" dataKey="jumlah" stroke="#8884d8" strokeWidth={2} dot />
+        </LineChart>
+      </ResponsiveContainer>
+    </div>
+  )
+
+  const barChart = (
+    <div style={{ width: "100%", height: 350 }}>
+      <ResponsiveContainer width="100%" height="100%">
+        <BarChart data={chartData}>
+          <CartesianGrid strokeDasharray="3 3" />
+          <XAxis dataKey="period" />
+          <YAxis allowDecimals={false} />
+          <RechartsTooltip />
+          <Bar dataKey="jumlah" fill="#82ca9d" />
+        </BarChart>
+      </ResponsiveContainer>
+    </div>
+  )
+
+  const noData = (
+    <p className="flex h-full items-center justify-center text-sm text-muted-foreground">
+      Tidak ada data untuk periode ini.
+    </p>
+  )
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Dashboard Survei</CardTitle>
+        <CardDescription>{getFilterDescription(filterType, selectedDate)}</CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-6">
+        <SurveyFilterCard
+          selectedUnit={selectedUnit}
+          setSelectedUnit={setSelectedUnit}
+          availableUnits={availableUnits}
+          filterType={filterType}
+          setFilterType={setFilterType}
+          selectedDate={selectedDate}
+          setSelectedDate={setSelectedDate}
+          chartType={chartType}
+          setChartType={setChartType}
+        />
+        <div className="text-center text-xl font-semibold">
+          Total Respon: {filteredSurveys.length}
+        </div>
+        {chartData.length > 0 ? (chartType === "line" ? lineChart : barChart) : noData}
+      </CardContent>
+    </Card>
+  )
+}
+

--- a/src/components/organisms/survey-filter-card.tsx
+++ b/src/components/organisms/survey-filter-card.tsx
@@ -1,0 +1,241 @@
+"use client"
+
+import * as React from "react"
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import { Button } from "@/components/ui/button"
+import { Label } from "@/components/ui/label"
+import {
+  Filter as FilterIcon,
+  Calendar as CalendarIcon,
+  LineChart as LineChartIcon,
+  BarChart as BarChartIcon,
+} from "lucide-react"
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover"
+import { Calendar } from "@/components/ui/calendar"
+import { format } from "date-fns"
+import { id as IndonesianLocale } from "date-fns/locale"
+import { cn } from "@/lib/utils"
+import type { FilterType } from "@/lib/indicator-utils"
+
+interface SurveyFilterCardProps {
+  selectedUnit: string
+  setSelectedUnit: (unit: string) => void
+  availableUnits: string[]
+  filterType: FilterType
+  setFilterType: (type: FilterType) => void
+  selectedDate: Date
+  setSelectedDate: (date: Date) => void
+  chartType: "line" | "bar"
+  setChartType: (type: "line" | "bar") => void
+}
+
+export function SurveyFilterCard({
+  selectedUnit,
+  setSelectedUnit,
+  availableUnits,
+  filterType,
+  setFilterType,
+  selectedDate,
+  setSelectedDate,
+  chartType,
+  setChartType,
+}: SurveyFilterCardProps) {
+  const renderDateInput = () => {
+    const currentYear = new Date().getFullYear()
+    const years = Array.from({ length: 5 }, (_, i) => currentYear - i)
+    const months = Array.from({ length: 12 }, (_, i) => ({
+      value: i,
+      label: format(new Date(currentYear, i), "MMMM", { locale: IndonesianLocale }),
+    }))
+
+    if (filterType === "daily") {
+      return (
+        <Popover>
+          <PopoverTrigger asChild>
+            <Button
+              variant="outline"
+              className={cn(
+                "w-[200px] justify-start text-left font-normal",
+                !selectedDate && "text-muted-foreground"
+              )}
+            >
+              <CalendarIcon className="mr-2 h-4 w-4" />
+              {selectedDate
+                ? format(selectedDate, "PPP", { locale: IndonesianLocale })
+                : <span>Pilih tanggal</span>}
+            </Button>
+          </PopoverTrigger>
+          <PopoverContent className="w-auto p-0" align="start">
+            <Calendar
+              mode="single"
+              selected={selectedDate}
+              onSelect={(date) => date && setSelectedDate(date)}
+              initialFocus
+              disabled={{ after: new Date() }}
+            />
+          </PopoverContent>
+        </Popover>
+      )
+    }
+
+    if (filterType === "monthly") {
+      return (
+        <div className="flex gap-2">
+          <Select
+            value={selectedDate.getMonth().toString()}
+            onValueChange={(v) =>
+              setSelectedDate(new Date(selectedDate.getFullYear(), parseInt(v)))
+            }
+          >
+            <SelectTrigger className="w-[150px]">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {months.map((m) => (
+                <SelectItem key={m.value} value={m.value.toString()}>
+                  {m.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          <Select
+            value={selectedDate.getFullYear().toString()}
+            onValueChange={(v) =>
+              setSelectedDate(new Date(parseInt(v), selectedDate.getMonth()))
+            }
+          >
+            <SelectTrigger className="w-[100px]">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {years.map((y) => (
+                <SelectItem key={y} value={y.toString()}>
+                  {y}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+      )
+    }
+
+    if (filterType === "yearly") {
+      return (
+        <Select
+          value={selectedDate.getFullYear().toString()}
+          onValueChange={(v) =>
+            setSelectedDate(new Date(parseInt(v), selectedDate.getMonth()))
+          }
+        >
+          <SelectTrigger className="w-[150px]">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            {years.map((y) => (
+              <SelectItem key={y} value={y.toString()}>
+                {y}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      )
+    }
+
+    return null
+  }
+
+  const showCustom = ["daily", "monthly", "yearly"].includes(filterType)
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>
+          <FilterIcon className="mr-2 h-5 w-5 inline-block" />
+          Filter & Tampilan Data
+        </CardTitle>
+        <CardDescription>
+          Sesuaikan unit, rentang waktu, dan tampilan grafik.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-6">
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+          <div className="space-y-2">
+            <Label>Unit</Label>
+            <Select value={selectedUnit} onValueChange={setSelectedUnit}>
+              <SelectTrigger className="w-full">
+                <SelectValue placeholder="Pilih unit" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="Semua">Semua Unit</SelectItem>
+                {availableUnits.map((u) => (
+                  <SelectItem key={u} value={u}>
+                    {u}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+          <div className="space-y-2">
+            <Label>Rentang Waktu</Label>
+            <Select value={filterType} onValueChange={(v) => setFilterType(v as FilterType)}>
+              <SelectTrigger className="w-full">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="7d">7 Hari Terakhir</SelectItem>
+                <SelectItem value="30d">30 Hari Terakhir</SelectItem>
+                <SelectItem value="3m">3 Bulan Terakhir</SelectItem>
+                <SelectItem value="6m">6 Bulan Terakhir</SelectItem>
+                <SelectItem value="1y">1 Tahun Terakhir</SelectItem>
+                <SelectItem value="daily">Harian (Kustom)</SelectItem>
+                <SelectItem value="monthly">Bulanan (Kustom)</SelectItem>
+                <SelectItem value="yearly">Tahunan (Kustom)</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+          <div className="space-y-2">
+            <Label>Tipe Grafik</Label>
+            <div className="flex items-center rounded-md border p-1 w-fit">
+              <Button
+                variant="ghost"
+                size="icon"
+                onClick={() => setChartType("line")}
+                className={cn("h-8 w-8", chartType === "line" && "bg-muted")}
+              >
+                <LineChartIcon className="h-4 w-4" />
+              </Button>
+              <Button
+                variant="ghost"
+                size="icon"
+                onClick={() => setChartType("bar")}
+                className={cn("h-8 w-8", chartType === "bar" && "bg-muted")}
+              >
+                <BarChartIcon className="h-4 w-4" />
+              </Button>
+            </div>
+          </div>
+        </div>
+        {showCustom && (
+          <div className="space-y-2">
+            <Label>Pilih Tanggal</Label>
+            {renderDateInput()}
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  )
+}
+

--- a/src/components/ui/command.tsx
+++ b/src/components/ui/command.tsx
@@ -7,7 +7,8 @@ import { Command as CommandPrimitive } from "cmdk"
 import { Search } from "lucide-react"
 
 import { cn } from "@/lib/utils"
-import { Dialog, DialogContent } from "@/components/ui/dialog"
+import { Dialog, DialogContent, DialogTitle } from "@/components/ui/dialog"
+import { VisuallyHidden } from "@radix-ui/react-visually-hidden"
 
 const Command = React.forwardRef<
   React.ElementRef<typeof CommandPrimitive>,
@@ -30,6 +31,9 @@ const CommandDialog = ({ children, ...props }: CommandDialogProps) => {
   return (
     <Dialog {...props}>
       <DialogContent className="overflow-hidden p-0 shadow-lg">
+        <VisuallyHidden>
+          <DialogTitle>Command Menu</DialogTitle>
+        </VisuallyHidden>
         <Command className="[&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground [&_[cmdk-group]:not([hidden])_~[cmdk-group]]:pt-0 [&_[cmdk-group]]:px-2 [&_[cmdk-input-wrapper]_svg]:h-5 [&_[cmdk-input-wrapper]_svg]:w-5 [&_[cmdk-input]]:h-12 [&_[cmdk-item]]:px-2 [&_[cmdk-item]]:py-3 [&_[cmdk-item]_svg]:h-5 [&_[cmdk-item]_svg]:w-5">
           {children}
         </Command>

--- a/src/lib/actions/auth.ts
+++ b/src/lib/actions/auth.ts
@@ -27,18 +27,21 @@ export async function login(formData: FormData) {
   }
 
   const expires = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000)
-  cookies().set("session", JSON.stringify(sessionUser), { expires, httpOnly: true })
+  const cookieStore = await cookies()
+  cookieStore.set("session", JSON.stringify(sessionUser), { expires, httpOnly: true })
 
   return sessionUser
 }
 
 export async function logout() {
   // Destroy the session
-  cookies().set("session", "", { expires: new Date(0) })
+  const cookieStore = await cookies()
+  cookieStore.set("session", "", { expires: new Date(0) })
 }
 
 export async function getSession() {
-  return cookies().get("session")?.value
+  const cookieStore = await cookies()
+  return cookieStore.get("session")?.value
 }
 
 export async function getCurrentUser() {


### PR DESCRIPTION
## Summary
- add survey dashboard components with unit and timeframe filters
- show total responses with switchable line or bar chart
- integrate dashboard into survey page

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run typecheck` *(fails: Cannot find module '@prisma/client' and other type errors)*

------
https://chatgpt.com/codex/tasks/task_b_68ac585d7c0c8325a2fce80c3f4699a9