### PR TITLE
Limit toast queue to one

### DIFF
--- a/src/hooks/use-toast.ts
+++ b/src/hooks/use-toast.ts
@@ -5,7 +5,8 @@ import * as React from "react"
 
 import type { ToastActionElement, ToastProps } from "@/components/ui/toast"
 
-const TOAST_LIMIT = 3
+// Limit to a single toast at a time to avoid overwhelming the UI
+const TOAST_LIMIT = 1
 const TOAST_REMOVE_DELAY = 5000
 
 type ToasterToast = ToastProps & {


### PR DESCRIPTION
## Summary
- prevent multiple toasts from appearing simultaneously by restricting the toast queue to a single item

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run typecheck` *(fails: various type errors)*

------
https://chatgpt.com/codex/tasks/task_b_68ac5f2d20c8832580da107ee8d5f5b3