### PR TITLE
fix cookies API usage and update zustand store creation

### DIFF
--- a/src/lib/actions/auth.ts
+++ b/src/lib/actions/auth.ts
@@ -27,18 +27,21 @@ export async function login(formData: FormData) {
   }
 
   const expires = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000)
-  cookies().set("session", JSON.stringify(sessionUser), { expires, httpOnly: true })
+  const cookieStore = await cookies()
+  cookieStore.set("session", JSON.stringify(sessionUser), { expires, httpOnly: true })
 
   return sessionUser
 }
 
 export async function logout() {
   // Destroy the session
-  cookies().set("session", "", { expires: new Date(0) })
+  const cookieStore = await cookies()
+  cookieStore.set("session", "", { expires: new Date(0) })
 }
 
 export async function getSession() {
-  return cookies().get("session")?.value
+  const cookieStore = await cookies()
+  return cookieStore.get("session")?.value
 }
 
 export async function getCurrentUser() {

--- a/src/store/incident-store.ts
+++ b/src/store/incident-store.ts
@@ -1,6 +1,6 @@
 "use client"
 
-import { create } from "zustand"
+import { createWithEqualityFn } from "zustand/traditional"
 
 export type IncidentStatus = "Investigasi" | "Selesai"
 
@@ -44,7 +44,7 @@ type IncidentState = {
   removeIncident: (id: string) => Promise<void>
 }
 
-export const useIncidentStore = create<IncidentState>((set) => ({
+export const useIncidentStore = createWithEqualityFn<IncidentState>()((set) => ({
   incidents: [],
 
   fetchIncidents: async () => {

--- a/src/store/indicator-store.ts
+++ b/src/store/indicator-store.ts
@@ -1,6 +1,6 @@
 "use client"
 
-import { create } from "zustand"
+import { createWithEqualityFn } from "zustand/traditional"
 import { calculateRatio, calculateStatus } from "@/lib/indicator-utils"
 
 export type IndicatorCategory = "INM" | "IMP-RS" | "IMPU" | "SPM"
@@ -78,7 +78,7 @@ const statusFromApi = (s: string): SubmittedIndicator["status"] =>
 const unitToApi = (u: "%" | "menit") => (u === "%" ? "persen" : "menit")
 const unitFromApi = (u: string): "%" | "menit" => (u === "persen" ? "%" : "menit")
 
-export const useIndicatorStore = create<IndicatorState>((set, get) => ({
+export const useIndicatorStore = createWithEqualityFn<IndicatorState>()((set, get) => ({
   indicators: [],
   submittedIndicators: [],
 

--- a/src/store/log-store.tsx
+++ b/src/store/log-store.tsx
@@ -1,7 +1,7 @@
 
 "use client"
 
-import { create } from 'zustand'
+import { createWithEqualityFn } from 'zustand/traditional'
 import React, { createContext, useContext, useRef } from 'react';
 
 type LogAction = 
@@ -35,7 +35,7 @@ type LogState = {
   addLog: (log: Omit<SystemLog, 'id' | 'timestamp'>) => void;
 }
 
-const createLogStore = () => create<LogState>()(
+const createLogStore = () => createWithEqualityFn<LogState>()(
     (set) => ({
         logs: [],
         addLog: (log) =>

--- a/src/store/notification-store.tsx
+++ b/src/store/notification-store.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { create } from "zustand"
+import { createWithEqualityFn } from "zustand/traditional"
 import { persist, createJSONStorage } from "zustand/middleware"
 import { shallow } from "zustand/shallow"
 import React, { createContext, useContext, useRef } from "react"
@@ -30,7 +30,7 @@ type NotificationState = {
 }
 
 const createNotificationStore = () =>
-  create<NotificationState>()(
+  createWithEqualityFn<NotificationState>()(
     persist(
       (set, get) => ({
         notifications: [],

--- a/src/store/risk-store.ts
+++ b/src/store/risk-store.ts
@@ -1,6 +1,6 @@
 "use client"
 
-import { create } from "zustand"
+import { createWithEqualityFn } from "zustand/traditional"
 
 export type RiskSource =
   | "Laporan Insiden"
@@ -152,7 +152,7 @@ const calculateRiskProperties = (risk: Partial<Risk>) => {
   return { cxl, riskLevel, riskScore, residualRiskScore, residualRiskLevel }
 }
 
-export const useRiskStore = create<RiskState>((set) => ({
+export const useRiskStore = createWithEqualityFn<RiskState>()((set) => ({
   risks: [],
 
   fetchRisks: async () => {

--- a/src/store/survey-store.ts
+++ b/src/store/survey-store.ts
@@ -1,7 +1,7 @@
 
 "use client"
 
-import { create } from "zustand"
+import { createWithEqualityFn } from "zustand/traditional"
 import { persist, createJSONStorage } from 'zustand/middleware'
 
 // --- Tipe Data ---
@@ -37,7 +37,7 @@ type SurveyState = {
 
 // --- Store Zustand ---
 
-export const useSurveyStore = create<SurveyState>()(
+export const useSurveyStore = createWithEqualityFn<SurveyState>()(
     persist(
         (set) => ({
             surveys: [], // Data awal kosong

--- a/src/store/user-store.tsx
+++ b/src/store/user-store.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { create } from "zustand"
+import { createWithEqualityFn } from "zustand/traditional"
 import React, { createContext, useContext, useEffect, useRef } from "react"
 import { useNotificationStore } from "./notification-store"
 import type { UserRole as DbUserRole } from "@prisma/client"
@@ -48,7 +48,7 @@ type UserState = {
 }
 
 const createUserStore = () =>
-  create<UserState>()((set, get) => ({
+  createWithEqualityFn<UserState>()((set, get) => ({
     users: [],
     currentUser: null,
     fetchUsers: async () => {


### PR DESCRIPTION
## Summary
- use async cookies API in auth actions
- replace deprecated `zustand` `create` calls with `createWithEqualityFn`

## Testing
- `npm run lint`
- `npm run typecheck` *(fails: Cannot find module '@prisma/client' and other type errors)*
- `npm run build` *(fails: Module not found: Can't resolve '@prisma/client')*


------
https://chatgpt.com/codex/tasks/task_b_68ac90a86e288325adf1510e95649756