### PR TITLE
fix: await cookies before session access

### DIFF
--- a/src/lib/actions/auth.ts
+++ b/src/lib/actions/auth.ts
@@ -27,18 +27,21 @@ export async function login(formData: FormData) {
   }
 
   const expires = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000)
-  cookies().set("session", JSON.stringify(sessionUser), { expires, httpOnly: true })
+  const cookieStore = await cookies()
+  cookieStore.set("session", JSON.stringify(sessionUser), { expires, httpOnly: true })
 
   return sessionUser
 }
 
 export async function logout() {
   // Destroy the session
-  cookies().set("session", "", { expires: new Date(0) })
+  const cookieStore = await cookies()
+  cookieStore.set("session", "", { expires: new Date(0) })
 }
 
 export async function getSession() {
-  return cookies().get("session")?.value
+  const cookieStore = await cookies()
+  return cookieStore.get("session")?.value
 }
 
 export async function getCurrentUser() {


### PR DESCRIPTION
## Summary
- await `cookies()` in auth actions to comply with Next.js async dynamic APIs

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run typecheck` *(fails: Cannot find module '@prisma/client', various TS errors)*

------
https://chatgpt.com/codex/tasks/task_b_68acfde8a5a083259f34231425f2743a