### PR TITLE
feat: ensure new survey form opens in dialog

### DIFF
--- a/src/app/dashboard/surveys/page.tsx
+++ b/src/app/dashboard/surveys/page.tsx
@@ -80,10 +80,17 @@ export default function SurveysPage() {
                   <Download className="mr-2 h-5 w-5" />
                   Unduh Laporan
               </Button>
-              <Button size="lg" onClick={() => setIsSurveyDialogOpen(true)}>
-                  <PlusCircle className="mr-2 h-5 w-5" />
-                  Isi Survei Baru
-              </Button>
+              <SurveyDialog
+                open={isSurveyDialogOpen}
+                onOpenChange={handleDialogChange}
+                survey={editingSurvey}
+                trigger={
+                  <Button size="lg">
+                    <PlusCircle className="mr-2 h-5 w-5" />
+                    Isi Survei Baru
+                  </Button>
+                }
+              />
             </div>
           </div>
         </CardHeader>
@@ -91,7 +98,6 @@ export default function SurveysPage() {
           <SurveyTable surveys={surveys} onEdit={(s) => { setEditingSurvey(s); setIsSurveyDialogOpen(true); }} />
         </CardContent>
       </Card>
-      <SurveyDialog open={isSurveyDialogOpen} onOpenChange={handleDialogChange} survey={editingSurvey} />
       <ReportPreviewDialog open={isPreviewOpen} onOpenChange={setIsPreviewOpen} csvData={csvData} onDownload={downloadCSV} />
     </div>
   );

--- a/src/components/organisms/survey-dialog.tsx
+++ b/src/components/organisms/survey-dialog.tsx
@@ -2,7 +2,7 @@
 "use client"
 
 import * as React from "react"
-import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from "@/components/ui/dialog"
+import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle, DialogTrigger } from "@/components/ui/dialog"
 import { SurveyForm } from "./survey-form"
 import { SurveyResult } from "@/store/survey-store"
 
@@ -10,13 +10,15 @@ type SurveyDialogProps = {
   open: boolean
   onOpenChange: (open: boolean) => void
   survey?: SurveyResult | null
+  trigger?: React.ReactNode
 }
 
-export function SurveyDialog({ open, onOpenChange, survey }: SurveyDialogProps) {
-  const isEdit = !!survey;
+export function SurveyDialog({ open, onOpenChange, survey, trigger }: SurveyDialogProps) {
+  const isEdit = !!survey
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-w-4xl">
+      {trigger && <DialogTrigger asChild>{trigger}</DialogTrigger>}
+      <DialogContent className="sm:max-w-4xl">
         <DialogHeader>
           <DialogTitle>{isEdit ? 'Edit Survei Budaya Keselamatan Pasien' : 'Survei Budaya Keselamatan Pasien'}</DialogTitle>
           <DialogDescription>


### PR DESCRIPTION
## Summary
- enable SurveyDialog to render an optional trigger and align width with other dialogs
- integrate SurveyDialog trigger button into surveys dashboard

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_b_68ad050e11288325ae62feb8c34efcb1