### PR TITLE
feat: add survey report preview with charts

### DIFF
--- a/src/app/dashboard/surveys/page.tsx
+++ b/src/app/dashboard/surveys/page.tsx
@@ -200,6 +200,7 @@ export default function SurveysPage() {
         lineChart={lineChart}
         barChart={barChart}
         analysisTable={analysisTable}
+        exportAsPdf
       />
       <SurveyDialog
         open={isSurveyDialogOpen}


### PR DESCRIPTION
## Summary
- add summary per unit, line chart, and bar chart to survey report preview
- show overall totals to help non-technical users understand survey data

## Testing
- `npm run lint`
- `npm run typecheck` *(fails: Cannot find module '@prisma/client' and other type errors)*

------
https://chatgpt.com/codex/tasks/task_b_68ad19988c5483259669430a0d50e841