### PR TITLE
refactor: modernize prisma seed and lint

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,3 +1,6 @@
 {
-  "extends": "next/core-web-vitals"
+  "extends": "next/core-web-vitals",
+  "rules": {
+    "max-lines": ["warn", { "max": 130, "skipBlankLines": true, "skipComments": true }]
+  }
 }

--- a/package.json
+++ b/package.json
@@ -13,8 +13,9 @@
     "format": "prettier --write .",
     "prisma:generate": "prisma generate",
     "prisma:migrate": "prisma migrate dev",
-    "db:seed": "node prisma/seed.js",
-    "reinstall": "rm -rf node_modules && npm cache clean --force && npm install"
+    "db:seed": "tsx prisma/seed.ts",
+    "reinstall": "rm -rf node_modules && npm cache clean --force && npm install",
+    "prebuild": "npm run lint"
   },
   "dependencies": {
     "@genkit-ai/googleai": "^1.14.1",

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -1,20 +1,9 @@
-/*
-  Prisma seed for initial users and SKP (Sasaran Keselamatan Pasien) triwulanan example.
-  Run after generating the Prisma Client and migrating the schema.
+import { PrismaClient, Prisma } from '@prisma/client'
 
-  Usage:
-    - Ensure DATABASE_URL points to your MySQL instance.
-    - npm run prisma:generate
-    - npx prisma migrate dev
-    - npm run db:seed
-*/
-
-const { PrismaClient } = require('@prisma/client')
 const prisma = new PrismaClient()
 
 async function main() {
-  // Seed Users
-  const users = [
+  const users: Prisma.UserCreateInput[] = [
     { name: 'Admin Sistem', email: 'admin@sim.rs', password: '123456', role: 'AdminSistem' },
     { name: 'Delina (PIC Mutu)', email: 'delina@sim.rs', password: '123456', role: 'PICMutu', unit: 'PPI' },
     { name: 'Deti (PJ Ruangan)', email: 'deti@sim.rs', password: '123456', role: 'PJRuangan', unit: 'RANAP' },
@@ -25,19 +14,9 @@ async function main() {
     { name: 'Dara (Manajemen Risiko)', email: 'dara@sim.rs', password: '123456', role: 'SubKomiteManajemenRisiko' },
   ]
 
-  const createdUsers = {}
-  for (const u of users) {
-    const user = await prisma.user.upsert({
-      where: { email: u.email },
-      update: {},
-      create: u,
-    })
-    createdUsers[u.email] = user
-  }
+  await prisma.user.createMany({ data: users, skipDuplicates: true })
+  const admin = await prisma.user.findUniqueOrThrow({ where: { email: 'admin@sim.rs' } })
 
-  const admin = createdUsers['admin@sim.rs']
-
-  // Seed SKP Triwulanan example as Indicator Profile + Submitted Indicator + quarterly Indicator records
   const profile = await prisma.indicatorProfile.upsert({
     where: { title: 'Kepatuhan Identifikasi Pasien' },
     update: {},
@@ -78,16 +57,14 @@ async function main() {
     },
   })
 
-  // Quarterly periods for the current year
   const year = new Date().getFullYear()
   const quarters = [
-    new Date(year, 2, 31),  // Q1 - Mar 31
-    new Date(year, 5, 30),  // Q2 - Jun 30
-    new Date(year, 8, 30),  // Q3 - Sep 30
-    new Date(year, 11, 31), // Q4 - Dec 31
+    new Date(year, 2, 31),
+    new Date(year, 5, 30),
+    new Date(year, 8, 30),
+    new Date(year, 11, 31),
   ]
 
-  // Example numbers for each quarter
   const samples = [
     { num: 190, den: 200 },
     { num: 280, den: 300 },
@@ -96,8 +73,7 @@ async function main() {
   ]
 
   for (let i = 0; i < quarters.length; i++) {
-    const n = samples[i].num
-    const d = samples[i].den
+    const { num: n, den: d } = samples[i]
     const ratio = d > 0 ? (n / d) * 100 : 0
     await prisma.indicator.create({
       data: {
@@ -124,4 +100,3 @@ main()
   .finally(async () => {
     await prisma.$disconnect()
   })
-

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -1,11 +1,11 @@
 
 import * as React from "react"
 import { Slot } from "@radix-ui/react-slot"
-import { cva, type VariantProps } from "class-variance-authority"
+import { cva } from "class-variance-authority"
 
 import { cn } from "@/lib/utils"
 
-const buttonVariants = cva(
+export const buttonVariants = cva(
   "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
   {
     variants: {
@@ -34,11 +34,7 @@ const buttonVariants = cva(
   }
 )
 
-export interface ButtonProps
-  extends React.ButtonHTMLAttributes<HTMLButtonElement>,
-    VariantProps<typeof buttonVariants> {
-  asChild?: boolean
-}
+import type { ButtonProps } from "./button.type"
 
 const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
   ({ className, variant, size, asChild = false, ...props }, ref) => {

--- a/src/components/ui/button.type.ts
+++ b/src/components/ui/button.type.ts
@@ -1,0 +1,9 @@
+import type * as React from "react"
+import type { VariantProps } from "class-variance-authority"
+import type { buttonVariants } from "./button"
+
+export interface ButtonProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement>,
+    VariantProps<typeof buttonVariants> {
+  asChild?: boolean
+}

--- a/src/components/ui/combobox.tsx
+++ b/src/components/ui/combobox.tsx
@@ -84,7 +84,7 @@ export function Combobox({ options, placeholder, searchPlaceholder, onSelect, va
                         setOpen(false);
                     }}
                 >
-                    Gunakan nilai: "{value}"
+                    Gunakan nilai: &quot;{value}&quot;
                 </button>
             </CommandEmpty>
             <CommandGroup>


### PR DESCRIPTION
## Summary
- convert Prisma seeding script to TypeScript and bulk insert users
- lint before builds and enforce 130 line warning
- split button props into a dedicated type file and fix combobox quote lint

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_68bb9d1204708324ad893f915ff2e566