### PR TITLE
fix: correct incident status update

### DIFF
--- a/src/components/organisms/incident-table/actions-cell.tsx
+++ b/src/components/organisms/incident-table/actions-cell.tsx
@@ -33,14 +33,14 @@ export function ActionsCell({ row, onViewDetails }: ActionsCellProps) {
   const incident = row.original
   const { currentUser } = useUserStore();
   const { addLog } = useLogStore();
-  const { updateIncident, removeIncident } = useIncidentStore()
+  const { updateIncidentStatus, removeIncident } = useIncidentStore()
   const { toast } = useToast();
   const [isEditDialogOpen, setIsEditDialogOpen] = React.useState(false)
 
   const canChangeStatus = currentUser?.role === 'Admin Sistem' || currentUser?.role === 'Sub. Komite Keselamatan Pasien';
 
   const handleStatusChange = async (status: IncidentStatus) => {
-    await updateIncident(incident.id, { status })
+    await updateIncidentStatus(incident.id, status)
     addLog({
       user: currentUser?.name || 'System',
       action: 'UPDATE_INCIDENT',


### PR DESCRIPTION
## Summary
- use dedicated updateIncidentStatus to change incident status

## Testing
- `npm run lint`
- `npm run typecheck` *(fails: Argument of type '{ data: Risk[]; columns: ColumnDef<Risk>[]; getCoreRowModel: ...}' is not assignable to parameter of type 'TableOptions<Risk>' and several other errors)*

------
https://chatgpt.com/codex/tasks/task_b_68bbd4dada3883249efdc5f1a1ff5581