### PR TITLE
refactor: extract component prop types

### DIFF
--- a/src/components/molecules/breadcrumb.tsx
+++ b/src/components/molecules/breadcrumb.tsx
@@ -5,11 +5,8 @@ import React from 'react';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import { ChevronRight } from 'lucide-react';
-import { NavItem } from '@/types/nav';
-
-type BreadcrumbProps = {
-  navItems: NavItem[];
-};
+import type { BreadcrumbProps } from './breadcrumb.type';
+import type { NavItem } from '@/types/nav';
 
 export function Breadcrumb({ navItems }: BreadcrumbProps) {
   const pathname = usePathname();

--- a/src/components/molecules/breadcrumb.type.ts
+++ b/src/components/molecules/breadcrumb.type.ts
@@ -1,0 +1,6 @@
+import type { NavItem } from '@/types/nav'
+
+export type BreadcrumbProps = {
+  navItems: NavItem[]
+}
+

--- a/src/components/molecules/form-input-date.tsx
+++ b/src/components/molecules/form-input-date.tsx
@@ -5,13 +5,7 @@ import * as React from "react"
 import { Label } from "../ui/label"
 import { Input } from "../ui/input"
 
-type FormInputDateProps = {
-  id: string
-  label: string
-  containerClassName?: string
-  selected?: Date
-  onSelect?: (date: Date | undefined) => void
-}
+import type { FormInputDateProps } from "./form-input-date.type"
 
 export function FormInputDate({ id, label, containerClassName = "grid grid-cols-1 md:grid-cols-form-label gap-x-4 gap-y-2 items-center", selected, onSelect }: FormInputDateProps) {
   const toValue = (d?: Date) => {

--- a/src/components/molecules/form-input-date.type.ts
+++ b/src/components/molecules/form-input-date.type.ts
@@ -1,0 +1,8 @@
+export type FormInputDateProps = {
+  id: string
+  label: string
+  containerClassName?: string
+  selected?: Date
+  onSelect?: (date: Date | undefined) => void
+}
+

--- a/src/components/molecules/form-input-radio.tsx
+++ b/src/components/molecules/form-input-radio.tsx
@@ -4,15 +4,7 @@
 import { Label } from "@/components/ui/label"
 import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group"
 
-type FormInputRadioProps = {
-  id: string
-  label: string
-  items: { value: string; label: string }[]
-  orientation?: 'horizontal' | 'vertical'
-  containerClassName?: string
-  value?: string
-  onValueChange?: (value: string) => void
-}
+import type { FormInputRadioProps } from "./form-input-radio.type"
 
 export function FormInputRadio({ id, label, items, orientation = 'horizontal', containerClassName = "grid grid-cols-1 md:grid-cols-form-label gap-x-4 gap-y-2 items-center", value, onValueChange }: FormInputRadioProps) {
   return (

--- a/src/components/molecules/form-input-radio.type.ts
+++ b/src/components/molecules/form-input-radio.type.ts
@@ -1,0 +1,10 @@
+export type FormInputRadioProps = {
+  id: string
+  label: string
+  items: { value: string; label: string }[]
+  orientation?: 'horizontal' | 'vertical'
+  containerClassName?: string
+  value?: string
+  onValueChange?: (value: string) => void
+}
+

--- a/src/components/molecules/form-input-select.tsx
+++ b/src/components/molecules/form-input-select.tsx
@@ -4,15 +4,7 @@
 import { Label } from "@/components/ui/label"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
 
-type FormInputSelectProps = {
-  id: string
-  label: string
-  placeholder: string
-  items: { value: string; label: string }[]
-  containerClassName?: string
-  value?: string
-  onValueChange?: (value: string) => void
-}
+import type { FormInputSelectProps } from "./form-input-select.type"
 
 export function FormInputSelect({ id, label, placeholder, items, containerClassName = "grid grid-cols-1 md:grid-cols-form-label gap-x-4 gap-y-2 items-center", value, onValueChange }: FormInputSelectProps) {
   return (

--- a/src/components/molecules/form-input-select.type.ts
+++ b/src/components/molecules/form-input-select.type.ts
@@ -1,0 +1,10 @@
+export type FormInputSelectProps = {
+  id: string
+  label: string
+  placeholder: string
+  items: { value: string; label: string }[]
+  containerClassName?: string
+  value?: string
+  onValueChange?: (value: string) => void
+}
+

--- a/src/components/molecules/form-input-text.tsx
+++ b/src/components/molecules/form-input-text.tsx
@@ -4,14 +4,7 @@
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 
-type FormInputTextProps = {
-  id: string
-  label: string
-  placeholder: string
-  containerClassName?: string
-  value?: string
-  onChange?: (event: React.ChangeEvent<HTMLInputElement>) => void
-}
+import type { FormInputTextProps } from "./form-input-text.type"
 
 export function FormInputText({ id, label, placeholder, containerClassName = "grid grid-cols-1 md:grid-cols-form-label gap-x-4 gap-y-2 items-center", value, onChange }: FormInputTextProps) {
   return (

--- a/src/components/molecules/form-input-text.type.ts
+++ b/src/components/molecules/form-input-text.type.ts
@@ -1,0 +1,11 @@
+import type React from "react"
+
+export type FormInputTextProps = {
+  id: string
+  label: string
+  placeholder: string
+  containerClassName?: string
+  value?: string
+  onChange?: (event: React.ChangeEvent<HTMLInputElement>) => void
+}
+

--- a/src/components/molecules/form-input-textarea.tsx
+++ b/src/components/molecules/form-input-textarea.tsx
@@ -4,14 +4,7 @@
 import { Label } from "@/components/ui/label"
 import { Textarea } from "@/components/ui/textarea"
 
-type FormInputTextareaProps = {
-  id: string
-  label: string
-  placeholder: string
-  containerClassName?: string
-  value?: string
-  onChange?: (event: React.ChangeEvent<HTMLTextAreaElement>) => void
-}
+import type { FormInputTextareaProps } from "./form-input-textarea.type"
 
 export function FormInputTextarea({ id, label, placeholder, containerClassName = "grid grid-cols-1 md:grid-cols-form-label-align-top gap-x-4 gap-y-2", value, onChange }: FormInputTextareaProps) {
   return (

--- a/src/components/molecules/form-input-textarea.type.ts
+++ b/src/components/molecules/form-input-textarea.type.ts
@@ -1,0 +1,11 @@
+import type React from "react"
+
+export type FormInputTextareaProps = {
+  id: string
+  label: string
+  placeholder: string
+  containerClassName?: string
+  value?: string
+  onChange?: (event: React.ChangeEvent<HTMLTextAreaElement>) => void
+}
+

--- a/src/components/molecules/form-input-time.tsx
+++ b/src/components/molecules/form-input-time.tsx
@@ -3,14 +3,7 @@
 
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
-
-type FormInputTimeProps = {
-  id: string
-  label: string
-  containerClassName?: string
-  value?: string
-  onChange?: (event: React.ChangeEvent<HTMLInputElement>) => void
-}
+import type { FormInputTimeProps } from "./form-input-time.type"
 
 export function FormInputTime({ id, label, containerClassName = "grid grid-cols-1 md:grid-cols-form-label gap-x-4 gap-y-2 items-center", value, onChange }: FormInputTimeProps) {
   return (

--- a/src/components/molecules/form-input-time.type.ts
+++ b/src/components/molecules/form-input-time.type.ts
@@ -1,0 +1,10 @@
+import type React from "react"
+
+export type FormInputTimeProps = {
+  id: string
+  label: string
+  containerClassName?: string
+  value?: string
+  onChange?: (event: React.ChangeEvent<HTMLInputElement>) => void
+}
+

--- a/src/components/molecules/indicator-table.tsx
+++ b/src/components/molecules/indicator-table.tsx
@@ -1,11 +1,7 @@
 "use client"
 
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table"
-import { Indicator } from "@/store/indicator-store"
-
-type IndicatorTableProps = {
-    indicators: Indicator[]
-}
+import type { IndicatorTableProps } from "./indicator-table.type"
 
 export function IndicatorTable({ indicators }: IndicatorTableProps) {
     return (

--- a/src/components/molecules/indicator-table.type.ts
+++ b/src/components/molecules/indicator-table.type.ts
@@ -1,0 +1,6 @@
+import type { Indicator } from "@/store/indicator-store"
+
+export type IndicatorTableProps = {
+  indicators: Indicator[]
+}
+

--- a/src/components/molecules/stepper.tsx
+++ b/src/components/molecules/stepper.tsx
@@ -3,17 +3,7 @@
 
 import { cn } from "@/lib/utils"
 import { Check } from "lucide-react"
-
-type Step = {
-    id: string
-    name: string
-}
-
-type StepperProps = {
-    steps: Step[]
-    currentStep: number
-    setCurrentStep: (step: number) => void
-}
+import type { StepperProps } from "./stepper.type"
 
 export function Stepper({ steps, currentStep, setCurrentStep }: StepperProps) {
     return (

--- a/src/components/molecules/stepper.type.ts
+++ b/src/components/molecules/stepper.type.ts
@@ -1,0 +1,11 @@
+export type Step = {
+  id: string
+  name: string
+}
+
+export type StepperProps = {
+  steps: Step[]
+  currentStep: number
+  setCurrentStep: (step: number) => void
+}
+

--- a/src/components/organisms/incident-detail-dialog.tsx
+++ b/src/components/organisms/incident-detail-dialog.tsx
@@ -8,6 +8,7 @@ import { Separator } from "@/components/ui/separator"
 import { Incident } from "@/store/incident-store"
 import { formatChronology, cn } from "@/lib/utils"
 import { Badge } from "../ui/badge"
+import type { IncidentDetailDialogProps } from "./incident-detail-dialog.type"
 
 const DetailSection = ({ title, children }: { title: string, children: React.ReactNode }) => (
     <div className="space-y-2">
@@ -68,12 +69,6 @@ const SeverityBadge = ({ severity }: { severity: Incident['severity'] }) => {
         merah: "bg-red-500 text-white border-red-500 hover:bg-red-500/80",
     }
     return <Badge variant="outline" className={cn("text-base", colorMap[severity])}>{severityMap[severity]}</Badge>
-}
-
-type IncidentDetailDialogProps = {
-    incident: Incident | null
-    open: boolean
-    onOpenChange: (open: boolean) => void
 }
 
 export const IncidentDetailDialog = ({ incident, open, onOpenChange }: IncidentDetailDialogProps) => {

--- a/src/components/organisms/incident-detail-dialog.type.ts
+++ b/src/components/organisms/incident-detail-dialog.type.ts
@@ -1,0 +1,8 @@
+import type { Incident } from "@/store/incident-store"
+
+export type IncidentDetailDialogProps = {
+  incident: Incident | null
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}
+

--- a/src/components/organisms/incident-report-form.tsx
+++ b/src/components/organisms/incident-report-form.tsx
@@ -12,17 +12,13 @@ import { Step1PatientData } from "./incident-report-form/step1-patient-data"
 import { Step2IncidentDetails } from "./incident-report-form/step2-incident-details"
 import { Step3FollowUp } from "./incident-report-form/step3-follow-up"
 import { useNotificationStore } from "@/store/notification-store.tsx"
+import type { IncidentReportFormProps } from "./incident-report-form.type"
 
 const steps = [
     { id: '01', name: 'Data Pasien' },
     { id: '02', name: 'Rincian Kejadian' },
     { id: '03', name: 'Tindak Lanjut & Pelaporan' },
 ]
-
-type IncidentReportFormProps = {
-    setOpen: (open: boolean) => void;
-    incident?: Incident;
-}
 
 export function IncidentReportForm({ setOpen, incident }: IncidentReportFormProps) {
     const [currentStep, setCurrentStep] = React.useState(0)

--- a/src/components/organisms/incident-report-form.type.ts
+++ b/src/components/organisms/incident-report-form.type.ts
@@ -1,0 +1,7 @@
+import type { Incident } from "@/store/incident-store"
+
+export type IncidentReportFormProps = {
+  setOpen: (open: boolean) => void;
+  incident?: Incident;
+}
+

--- a/src/components/organisms/incident-report-form/step1-patient-data.interface.ts
+++ b/src/components/organisms/incident-report-form/step1-patient-data.interface.ts
@@ -1,0 +1,7 @@
+import type { Incident } from "@/store/incident-store"
+
+export interface Step1PatientDataProps {
+  data: Partial<Incident>;
+  onUpdate: (newData: Partial<Incident>) => void;
+}
+

--- a/src/components/organisms/incident-report-form/step1-patient-data.tsx
+++ b/src/components/organisms/incident-report-form/step1-patient-data.tsx
@@ -10,15 +10,11 @@ import { FormInputSelect } from "@/components/molecules/form-input-select"
 import { FormInputDate } from "@/components/molecules/form-input-date"
 import { FormInputTime } from "@/components/molecules/form-input-time"
 import { HOSPITAL_UNITS } from "@/lib/constants"
+import type { Step1PatientDataProps } from "./step1-patient-data.interface"
 
 const SectionTitle = ({ children }: { children: React.ReactNode }) => (
     <h3 className="font-semibold text-lg text-primary">{children}</h3>
 )
-
-type StepProps = {
-    data: Partial<Incident>;
-    onUpdate: (newData: Partial<Incident>) => void;
-};
 
 const unitOptions = HOSPITAL_UNITS.map(unit => ({ value: unit, label: unit }));
 const genderOptions = [{ value: 'Perempuan', label: 'Perempuan' }, { value: 'Laki-laki', label: 'Laki-laki' }];
@@ -34,7 +30,7 @@ const payerOptions = [
     { value: 'Asuransi Lainnya', label: 'Asuransi Lainnya' }
 ];
 
-export function Step1PatientData({ data, onUpdate }: StepProps) {
+export function Step1PatientData({ data, onUpdate }: Step1PatientDataProps) {
     return (
         <div className="space-y-6">
             <SectionTitle>Data Pasien (diisi oleh perawat)</SectionTitle>

--- a/src/components/organisms/indicator-filter-card.tsx
+++ b/src/components/organisms/indicator-filter-card.tsx
@@ -26,24 +26,10 @@ import { format } from "date-fns"
 import { id as IndonesianLocale } from "date-fns/locale"
 import { cn } from "@/lib/utils"
 import { HOSPITAL_UNITS } from "@/lib/constants"
-import { FilterType } from "@/lib/indicator-utils"
+import type { FilterType } from "@/lib/indicator-utils"
+import type { IndicatorFilterCardProps } from "./indicator-filter-card.type"
 
 const unitOptions = [{ value: "Semua Unit", label: "Semua Unit" }, ...HOSPITAL_UNITS.map(u => ({ value: u, label: u }))];
-
-type IndicatorFilterCardProps = {
-  userIsCentral: boolean;
-  selectedUnit: string;
-  setSelectedUnit: (unit: string) => void;
-  uniqueIndicatorNames: { value: string; label: string }[];
-  selectedIndicator: string;
-  setSelectedIndicator: (indicator: string) => void;
-  filterType: FilterType;
-  setFilterType: (type: FilterType) => void;
-  selectedDate: Date;
-  setSelectedDate: (date: Date) => void;
-  chartType: 'line' | 'bar';
-  setChartType: (type: 'line' | 'bar') => void;
-}
 
 export function IndicatorFilterCard({
   userIsCentral,

--- a/src/components/organisms/indicator-filter-card.type.ts
+++ b/src/components/organisms/indicator-filter-card.type.ts
@@ -1,0 +1,17 @@
+import type { FilterType } from "@/lib/indicator-utils"
+
+export type IndicatorFilterCardProps = {
+  userIsCentral: boolean;
+  selectedUnit: string;
+  setSelectedUnit: (unit: string) => void;
+  uniqueIndicatorNames: { value: string; label: string }[];
+  selectedIndicator: string;
+  setSelectedIndicator: (indicator: string) => void;
+  filterType: FilterType;
+  setFilterType: (type: FilterType) => void;
+  selectedDate: Date;
+  setSelectedDate: (date: Date) => void;
+  chartType: 'line' | 'bar';
+  setChartType: (type: 'line' | 'bar') => void;
+}
+

--- a/src/components/organisms/indicator-report.tsx
+++ b/src/components/organisms/indicator-report.tsx
@@ -17,18 +17,9 @@ import { CartesianGrid, LabelList, ResponsiveContainer, Tooltip as RechartsToolt
 import { format, parseISO } from "date-fns"
 import { AnalysisTable } from "./analysis-table"
 import {centralRoles} from "@/store/central-roles.ts";
+import type { IndicatorReportProps } from "./indicator-report.type"
 
 
-
-type IndicatorReportProps = {
-    indicators: Indicator[];
-    category: IndicatorCategory;
-    title?: string;
-    description?: string;
-    showInputButton?: boolean;
-    chartData?: any[]; // Allow passing chart data
-    reportDescription?: string;
-}
 
 export function IndicatorReport({ indicators, category, title, description, showInputButton = true, chartData, reportDescription }: IndicatorReportProps) {
     const { submittedIndicators } = useIndicatorStore()

--- a/src/components/organisms/indicator-report.type.ts
+++ b/src/components/organisms/indicator-report.type.ts
@@ -1,0 +1,12 @@
+import type { Indicator, IndicatorCategory } from "@/store/indicator-store"
+
+export type IndicatorReportProps = {
+  indicators: Indicator[];
+  category: IndicatorCategory;
+  title?: string;
+  description?: string;
+  showInputButton?: boolean;
+  chartData?: any[]; // Allow passing chart data
+  reportDescription?: string;
+}
+

--- a/src/components/organisms/indicator-submission-table.tsx
+++ b/src/components/organisms/indicator-submission-table.tsx
@@ -28,6 +28,7 @@ import { SubmittedIndicator, IndicatorCategory } from "@/store/indicator-store"
 import { useTableState } from "@/hooks/use-table-state"
 import { ActionsCell } from "./indicator-submission-table/actions-cell"
 import { TableFilters, dateRangeFilter, categoryFilter, statusFilter, getStatusVariant } from "./indicator-submission-table/table-filters"
+import type { IndicatorSubmissionTableProps } from "./indicator-submission-table.type"
 
 export const statusOptions: SubmittedIndicator['status'][] = ['Menunggu Persetujuan', 'Diverifikasi', 'Ditolak'];
 export const categoryOptions: {value: IndicatorCategory, label: string}[] = [
@@ -36,10 +37,6 @@ export const categoryOptions: {value: IndicatorCategory, label: string}[] = [
     { value: 'IMPU', label: 'IMPU'},
     { value: 'SPM', label: 'SPM'},
 ]
-
-type IndicatorSubmissionTableProps = {
-  indicators: SubmittedIndicator[]
-}
 
 export function IndicatorSubmissionTable({ indicators }: IndicatorSubmissionTableProps) {
   const { tableState, setTableState } = useTableState({

--- a/src/components/organisms/indicator-submission-table.type.ts
+++ b/src/components/organisms/indicator-submission-table.type.ts
@@ -1,0 +1,6 @@
+import type { SubmittedIndicator } from "@/store/indicator-store"
+
+export type IndicatorSubmissionTableProps = {
+  indicators: SubmittedIndicator[]
+}
+

--- a/src/components/organisms/profile-form.tsx
+++ b/src/components/organisms/profile-form.tsx
@@ -27,6 +27,7 @@ import { useUserStore, UserRole } from "@/store/user-store.tsx"
 import { useLogStore } from "@/store/log-store.tsx"
 import { HOSPITAL_UNITS } from "@/lib/constants"
 import { Combobox } from "../ui/combobox"
+import type { ProfileFormProps } from "./profile-form.type"
 
 const profileSchema = z.object({
   title: z.string().min(1, "Judul harus diisi."),
@@ -47,11 +48,6 @@ const profileSchema = z.object({
   pic: z.string().min(1, "PIC harus diisi."),
   unit: z.string().min(1, "Unit harus dipilih."),
 })
-
-type ProfileFormProps = {
-    setOpen: (open: boolean) => void;
-    profileToEdit?: IndicatorProfile;
-}
 
 const unitOptions = HOSPITAL_UNITS.map(unit => ({ value: unit, label: unit }));
 const roleOptions: {value: UserRole, label: string}[] = [

--- a/src/components/organisms/profile-form.type.ts
+++ b/src/components/organisms/profile-form.type.ts
@@ -1,0 +1,7 @@
+import type { IndicatorProfile } from "@/store/indicator-store"
+
+export type ProfileFormProps = {
+  setOpen: (open: boolean) => void;
+  profileToEdit?: IndicatorProfile;
+}
+

--- a/src/components/organisms/risk-report-table.tsx
+++ b/src/components/organisms/risk-report-table.tsx
@@ -21,6 +21,7 @@ import { format, parseISO } from "date-fns"
 import { id as IndonesianLocale } from "date-fns/locale"
 import { cn } from "@/lib/utils"
 import { defaultFilterFns } from "@/lib/default-filter-fns"
+import type { RiskReportTableProps } from "./risk-report-table.type"
 
 const evaluationMap: Record<RiskEvaluation, string> = {
     "Mitigasi": "1. Mitigasi",
@@ -61,10 +62,6 @@ const columns: ColumnDef<Risk>[] = [
     { accessorKey: "reportNotes", header: "Laporan Singkat / Monev", cell: info => info.getValue() || "-", size: 200 },
     { accessorKey: "status", header: "Status", cell: info => info.getValue(), size: 50 },
 ];
-
-type RiskReportTableProps = {
-  data: Risk[]
-}
 
 export function RiskReportTable({ data }: RiskReportTableProps) {
   const table = useReactTable({

--- a/src/components/organisms/risk-report-table.type.ts
+++ b/src/components/organisms/risk-report-table.type.ts
@@ -1,0 +1,6 @@
+import type { Risk } from "@/store/risk-store"
+
+export type RiskReportTableProps = {
+  data: Risk[]
+}
+

--- a/src/components/organisms/risk-table.tsx
+++ b/src/components/organisms/risk-table.tsx
@@ -44,6 +44,7 @@ import { Input } from "../ui/input"
 import { AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent, AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle, AlertDialogTrigger } from "../ui/alert-dialog"
 import { useToast } from "@/hooks/use-toast"
 import { defaultFilterFns } from "@/lib/default-filter-fns"
+import type { RiskTableProps } from "./risk-table.type"
 
 
 const ActionsCell = ({ row }: { row: Row<Risk> }) => {
@@ -269,10 +270,6 @@ const columns: ColumnDef<Risk>[] = [
     size: 50,
   },
 ]
-
-type RiskTableProps = {
-  risks: Risk[]
-}
 
 const riskLevelOptions: RiskLevel[] = ["Rendah", "Moderat", "Tinggi", "Ekstrem"];
 const statusOptions: RiskStatus[] = ["Open", "In Progress", "Closed"];

--- a/src/components/organisms/risk-table.type.ts
+++ b/src/components/organisms/risk-table.type.ts
@@ -1,0 +1,6 @@
+import type { Risk } from "@/store/risk-store"
+
+export type RiskTableProps = {
+  risks: Risk[]
+}
+

--- a/src/components/organisms/survey-dialog.tsx
+++ b/src/components/organisms/survey-dialog.tsx
@@ -5,13 +5,7 @@ import * as React from "react"
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle, DialogTrigger } from "@/components/ui/dialog"
 import { SurveyForm } from "./survey-form"
 import { SurveyResult } from "@/store/survey-store"
-
-type SurveyDialogProps = {
-  open: boolean
-  onOpenChange: (open: boolean) => void
-  survey?: SurveyResult | null
-  trigger?: React.ReactNode
-}
+import type { SurveyDialogProps } from "./survey-dialog.type"
 
 export function SurveyDialog({ open, onOpenChange, survey, trigger }: SurveyDialogProps) {
   const isEdit = !!survey

--- a/src/components/organisms/survey-dialog.type.ts
+++ b/src/components/organisms/survey-dialog.type.ts
@@ -1,0 +1,10 @@
+import type { ReactNode } from "react"
+import type { SurveyResult } from "@/store/survey-store"
+
+export type SurveyDialogProps = {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  survey?: SurveyResult | null
+  trigger?: ReactNode
+}
+

--- a/src/components/organisms/user-table.tsx
+++ b/src/components/organisms/user-table.tsx
@@ -43,6 +43,7 @@ import { UserDialog } from "./user-dialog"
 import { AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent, AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle, AlertDialogTrigger } from "../ui/alert-dialog"
 import { useLogStore } from "@/store/log-store.tsx"
 import { useToast } from "@/hooks/use-toast"
+import type { UserTableProps } from "./user-table.type"
 
 
 const ActionsCell = ({ row }: { row: Row<User> }) => {
@@ -157,10 +158,6 @@ export const columns: ColumnDef<User>[] = [
 ]
 
 const roleOptions: UserRole[] = ['Admin Sistem', 'PIC Mutu', 'PJ Ruangan', 'Kepala Unit/Instalasi', 'Direktur', 'Sub. Komite Peningkatan Mutu', 'Sub. Komite Keselamatan Pasien', 'Sub. Komite Manajemen Risiko'];
-
-type UserTableProps = {
-  users: User[]
-}
 
 export function UserTable({ users }: UserTableProps) {
   const [sorting, setSorting] = React.useState<SortingState>([])

--- a/src/components/organisms/user-table.type.ts
+++ b/src/components/organisms/user-table.type.ts
@@ -1,0 +1,6 @@
+import type { User } from "@/store/user-store.tsx"
+
+export type UserTableProps = {
+  users: User[]
+}
+


### PR DESCRIPTION
## Summary
- move prop types for key organism components into dedicated `.type.ts` files
- simplify component files by importing shared types

## Testing
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_b_68bbe6b8ecd88324aa7b51988c47cc94