### PR TITLE
Simplify incident actions dropdown

### DIFF
--- a/src/app/dashboard/incidents/page.tsx
+++ b/src/app/dashboard/incidents/page.tsx
@@ -10,13 +10,22 @@ import {
   CardTitle,
 } from "@/components/ui/card"
 import { IncidentReportDialog } from "@/components/organisms/incident-report-dialog"
-import { IncidentTable } from "@/components/organisms/incident-table"
+import {
+  IncidentTable,
+  type IncidentTableHandle,
+} from "@/components/organisms/incident-table"
 import { IncidentFilterCard } from "@/components/organisms/incident-filter-card"
 import { useIncidentStore } from "@/store/incident-store"
 import { useUserStore } from "@/store/user-store.tsx"
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert"
 import { PlusCircle, ShieldAlert, Download } from "lucide-react"
 import { Button } from "@/components/ui/button"
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu"
 import {
   ResponsiveContainer,
   LineChart,
@@ -46,6 +55,7 @@ export default function IncidentsPage() {
   const [chartType, setChartType] = React.useState<"line" | "bar">("line")
   const [selectedRiskType, setSelectedRiskType] = React.useState<string>("Semua")
   const [selectedRiskLevel, setSelectedRiskLevel] = React.useState<string>("Semua")
+  const incidentTableRef = React.useRef<IncidentTableHandle>(null)
 
   const dashboardRoles = [
     "Direktur",
@@ -361,16 +371,32 @@ export default function IncidentsPage() {
                   </CardDescription>
                 </div>
                 <div className="flex items-center gap-2">
-                  <Button variant="outline" size="lg" onClick={handleDownloadXlsx}>
-                    <Download className="mr-2 h-5 w-5" />
-                    Unduh Excel (.xlsx)
-                  </Button>
+                  <DropdownMenu>
+                    <DropdownMenuTrigger asChild>
+                      <Button variant="outline" size="lg">
+                        <Download className="mr-2 h-5 w-5" />
+                        Laporan & Unduhan
+                      </Button>
+                    </DropdownMenuTrigger>
+                    <DropdownMenuContent align="end">
+                      <DropdownMenuItem onClick={handleDownloadXlsx}>
+                        Unduh Excel (.xlsx)
+                      </DropdownMenuItem>
+                      <DropdownMenuItem onClick={() => incidentTableRef.current?.openExport()}>
+                        Unduh Daftar Insiden
+                      </DropdownMenuItem>
+                      <DropdownMenuItem onClick={() => incidentTableRef.current?.openSkpReport()}>
+                        Laporan SKP Triwulan
+                      </DropdownMenuItem>
+                    </DropdownMenuContent>
+                  </DropdownMenu>
                   <AddNewButton />
                 </div>
               </div>
             </CardHeader>
             <CardContent>
               <IncidentTable
+                ref={incidentTableRef}
                 incidents={filteredIncidents}
                 lineChart={incidentChartData.length > 0 ? lineChart : noDataMessage}
                 barChart={incidentChartData.length > 0 ? barChart : noDataMessage}

--- a/src/components/organisms/incident-table.tsx
+++ b/src/components/organisms/incident-table.tsx
@@ -12,8 +12,6 @@ import {
   getSortedRowModel,
   useReactTable,
 } from "@tanstack/react-table"
-import { Download, FileText } from "lucide-react"
-
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import {
@@ -36,7 +34,18 @@ import {
   getExportColumns,
 } from "./incident-table.utils"
 
-export function IncidentTable({ incidents, lineChart, barChart, chartDescription }: IncidentTableProps) {
+export type IncidentTableHandle = {
+  openExport: () => void
+  openSkpReport: () => void
+}
+
+export const IncidentTable = React.forwardRef<
+  IncidentTableHandle,
+  IncidentTableProps
+>(function IncidentTable(
+  { incidents, lineChart, barChart, chartDescription },
+  ref
+) {
   const [sorting, setSorting] = React.useState<SortingState>([])
   const [columnFilters, setColumnFilters] = React.useState<ColumnFiltersState>([])
   const [selectedIncident, setSelectedIncident] = React.useState<Incident | null>(null);
@@ -74,9 +83,10 @@ export function IncidentTable({ incidents, lineChart, barChart, chartDescription
     },
   })
   
-  const handleExport = () => {
-    setIsPreviewOpen(true)
-  }
+  React.useImperativeHandle(ref, () => ({
+    openExport: () => setIsPreviewOpen(true),
+    openSkpReport: () => setIsSkpReportOpen(true),
+  }))
 
 
   return (
@@ -90,21 +100,6 @@ export function IncidentTable({ incidents, lineChart, barChart, chartDescription
           }
           className="max-w-sm"
         />
-        <div className="ml-auto flex items-center gap-2">
-            <Button
-                variant="outline"
-                onClick={handleExport}
-                >
-                <Download className="mr-2 h-4 w-4" />
-                Unduh Daftar Insiden
-            </Button>
-            <Button
-                onClick={() => setIsSkpReportOpen(true)}
-                >
-                <FileText className="mr-2 h-4 w-4" />
-                Laporan SKP Triwulan
-            </Button>
-        </div>
       </div>
       <div className="rounded-md border">
         <Table>
@@ -168,4 +163,4 @@ export function IncidentTable({ incidents, lineChart, barChart, chartDescription
       <SkpReportDialog open={isSkpReportOpen} onOpenChange={setIsSkpReportOpen} />
     </div>
   )
-}
+})


### PR DESCRIPTION
## Summary
- replace multiple incident export buttons with a single dropdown for downloads and reports
- expose incident table actions via ref for external control

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68be3e79ad508324b526f8c71d63970c