### PR TITLE
fix: cascade delete related indicators

### DIFF
--- a/src/app/api/submitted-indicators/[id]/route.ts
+++ b/src/app/api/submitted-indicators/[id]/route.ts
@@ -35,7 +35,10 @@ export async function DELETE(
 ) {
   try {
     const { id } = await params
-    await prisma.submittedIndicator.delete({ where: { id } })
+    await prisma.$transaction([
+      prisma.indicator.deleteMany({ where: { submissionId: id } }),
+      prisma.submittedIndicator.delete({ where: { id } }),
+    ])
     return NextResponse.json({ ok: true })
   } catch (e: any) {
     return NextResponse.json({ error: e.message || 'Failed to delete submitted indicator' }, { status: 500 })


### PR DESCRIPTION
## Summary
- delete indicator achievements before deleting submission to avoid foreign key constraint

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_b_68be420e9e2883248606200af618de1d