### PR TITLE
Add copy-to-clipboard option for risk reports

### DIFF
--- a/src/app/dashboard/risks/page.tsx
+++ b/src/app/dashboard/risks/page.tsx
@@ -2,16 +2,18 @@
 "use client"
 
 import * as React from "react"
-import { BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer, PieChart, Pie, Cell, Legend } from "recharts"
+import { BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer, PieChart, Pie, Cell, Legend, LabelList } from "recharts"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
-import { Download, PlusCircle, AlertTriangle, ListTodo, ShieldCheck } from "lucide-react"
+import { Download, PlusCircle, AlertTriangle, ListTodo, ShieldCheck, Copy } from "lucide-react"
 import { useRiskStore, Risk, RiskLevel, RiskStatus } from "@/store/risk-store"
 import { RiskDialog } from "@/components/organisms/risk-dialog"
 import { RiskTable } from "@/components/organisms/risk-table"
 import { ReportPreviewDialog } from "@/components/organisms/report-preview-dialog"
 import { RiskReportTable } from "@/components/organisms/risk-report-table"
 import { RiskAnalysisTable } from "@/components/organisms/risk-analysis-table"
+import { copyChartImage } from "@/lib/copy-chart"
+import { useToast } from "@/hooks/use-toast"
 
 
 const COLORS: {[key in RiskLevel]: string} = {
@@ -21,10 +23,16 @@ const COLORS: {[key in RiskLevel]: string} = {
   Rendah: "hsl(var(--chart-5))",
 };
 
-const STATUS_COLORS: {[key in RiskStatus]: string} = {
-  Open: "hsl(var(--chart-2))",
-  'In Progress': "hsl(var(--chart-4))",
+const STATUS_COLORS: { [key in RiskStatus]: string } = {
+  Open: "hsl(var(--destructive))",
+  'In Progress': "#f59e0b",
   Closed: "hsl(var(--primary))",
+};
+
+const STATUS_COLOR_NAMES: { [key in RiskStatus]: string } = {
+  Open: "Merah",
+  'In Progress': "Kuning",
+  Closed: "Hijau",
 };
 
 
@@ -32,6 +40,9 @@ export default function RisksPage() {
     const [isDialogOpen, setIsDialogOpen] = React.useState(false)
     const [isReportOpen, setIsReportOpen] = React.useState(false)
     const { risks, fetchRisks } = useRiskStore()
+    const { toast } = useToast()
+    const levelChartRef = React.useRef<HTMLDivElement>(null)
+    const statusChartRef = React.useRef<HTMLDivElement>(null)
     React.useEffect(() => {
         fetchRisks().catch(() => {})
     }, [fetchRisks])
@@ -40,9 +51,13 @@ export default function RisksPage() {
         const levelCounts: Record<RiskLevel, number> = { Ekstrem: 0, Tinggi: 0, Moderat: 0, Rendah: 0 };
         const statusCounts: Record<RiskStatus, number> = { Open: 0, 'In Progress': 0, Closed: 0 };
 
-        risks.forEach(risk => {
+        risks.forEach((risk) => {
             levelCounts[risk.riskLevel]++;
-            statusCounts[risk.status]++;
+            const rawStatus = risk.status as string;
+            const status = rawStatus === 'InProgress' ? 'In Progress' : rawStatus;
+            if (statusCounts[status as RiskStatus] !== undefined) {
+                statusCounts[status as RiskStatus]++;
+            }
         });
 
         return {
@@ -50,13 +65,73 @@ export default function RisksPage() {
             open: statusCounts['Open'],
             extreme: levelCounts['Ekstrem'],
             levelData: Object.entries(levelCounts).map(([name, value]) => ({ name, value })).reverse(),
-            statusData: Object.entries(statusCounts).map(([name, value]) => ({ name, value }))
+            statusData: Object.entries(statusCounts).map(([name, value]) => ({
+                name,
+                value,
+                color: STATUS_COLORS[name as RiskStatus],
+                colorName: STATUS_COLOR_NAMES[name as RiskStatus],
+            }))
         };
     }, [risks]);
     
     const risksInProgress = React.useMemo(() => {
         return risks.filter(r => r.status === 'Open' || r.status === 'In Progress');
     }, [risks]);
+
+    const tooltipContent = ({ active, payload, label }: any) => {
+        if (active && payload && payload.length) {
+            const entry = payload[0]
+            const name = entry.payload?.name ?? label
+            const color =
+                entry.payload?.color ||
+                STATUS_COLORS[name as RiskStatus] ||
+                COLORS[name as RiskLevel] ||
+                entry.color ||
+                entry.fill
+            return (
+                <div
+                    className="rounded border bg-background p-2 text-sm shadow"
+                    style={{ color }}
+                >
+                    {`${name}: ${entry.value}`}
+                </div>
+            )
+        }
+        return null
+    }
+
+    const renderLevelLabel = (props: any) => {
+        const { x, y, value, index } = props
+        const entry = summary.levelData[index]
+        return (
+            <text
+                x={(x ?? 0) + 4}
+                y={y}
+                fill={COLORS[entry.name as RiskLevel]}
+                dominantBaseline="middle"
+                fontWeight={600}
+            >
+                {value}
+            </text>
+        )
+    }
+
+    const renderStatusLabel = (props: any) => {
+        const { x, y, value, index, textAnchor } = props
+        const entry = summary.statusData[index]
+        return (
+            <text
+                x={x}
+                y={y}
+                fill={STATUS_COLORS[entry.name as RiskStatus]}
+                textAnchor={textAnchor}
+                dominantBaseline="middle"
+                fontWeight={600}
+            >
+                {`${entry.name}: ${value}`}
+            </text>
+        )
+    }
 
     return (
         <div className="flex-1 space-y-4 p-4 md:p-8 pt-6">
@@ -97,53 +172,93 @@ export default function RisksPage() {
             
             <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-7">
                 <Card className="lg:col-span-4">
-                     <CardHeader>
+                     <CardHeader className="flex items-center justify-between">
+                        <div>
                         <CardTitle>Distribusi Level Risiko</CardTitle>
                         <CardDescription>Jumlah risiko berdasarkan tingkat bahayanya.</CardDescription>
+                        </div>
+                        <Button
+                          variant="ghost"
+                          size="icon"
+                          onClick={async () => {
+                            try {
+                              await copyChartImage(levelChartRef.current, summary.levelData)
+                              toast({ title: "Diagram Disalin", description: "Grafik level risiko tersalin." })
+                            } catch {
+                              toast({ title: "Gagal Menyalin", description: "Tidak dapat menyalin grafik." })
+                            }
+                          }}
+                        >
+                          <Copy className="h-4 w-4" />
+                        </Button>
                     </CardHeader>
                     <CardContent>
-                        <ResponsiveContainer width="100%" height={300}>
+                        <div ref={levelChartRef} className="h-[300px]">
+                        <ResponsiveContainer width="100%" height="100%">
                             <BarChart data={summary.levelData} layout="vertical" margin={{ left: 10 }}>
                                 <CartesianGrid strokeDasharray="3 3" horizontal={false} />
                                 <XAxis type="number" allowDecimals={false} />
                                 <YAxis type="category" dataKey="name" width={80} />
-                                <Tooltip cursor={{ fill: 'hsl(var(--muted))' }} />
+                                <Tooltip cursor={{ fill: 'hsl(var(--muted))' }} content={tooltipContent} />
                                 <Bar dataKey="value" name="Jumlah Risiko" barSize={40}>
+                                    <LabelList content={renderLevelLabel} />
                                     {summary.levelData.map((entry, index) => (
                                         <Cell key={`cell-${index}`} fill={COLORS[entry.name as RiskLevel]} />
                                     ))}
                                 </Bar>
                             </BarChart>
                         </ResponsiveContainer>
+                        </div>
                     </CardContent>
                 </Card>
                 <Card className="lg:col-span-3">
-                     <CardHeader>
+                     <CardHeader className="flex items-center justify-between">
+                        <div>
                         <CardTitle>Status Penyelesaian</CardTitle>
                         <CardDescription>Proporsi risiko berdasarkan status penanganannya.</CardDescription>
+                        </div>
+                        <Button
+                          variant="ghost"
+                          size="icon"
+                          onClick={async () => {
+                            try {
+                              await copyChartImage(statusChartRef.current, summary.statusData)
+                              toast({ title: "Diagram Disalin", description: "Grafik status tersalin." })
+                            } catch {
+                              toast({ title: "Gagal Menyalin", description: "Tidak dapat menyalin grafik." })
+                            }
+                          }}
+                        >
+                          <Copy className="h-4 w-4" />
+                        </Button>
                     </CardHeader>
                     <CardContent>
-                        <ResponsiveContainer width="100%" height={300}>
-                            <PieChart>
+                        <div ref={statusChartRef} className="h-[300px]">
+                        <ResponsiveContainer width="100%" height="100%">
+                                <PieChart>
                                 <Pie
                                     data={summary.statusData}
                                     cx="50%"
                                     cy="50%"
-                                    labelLine={false}
                                     outerRadius={80}
-                                    fill="#8884d8"
                                     dataKey="value"
                                     nameKey="name"
-                                    label={({ name, percent }) => `${name} ${(percent * 100).toFixed(0)}%`}
+                                    paddingAngle={2}
                                 >
                                     {summary.statusData.map((entry, index) => (
-                                    <Cell key={`cell-${index}`} fill={STATUS_COLORS[entry.name as RiskStatus]} />
+                                    <Cell
+                                        key={`cell-${index}`}
+                                        fill={STATUS_COLORS[entry.name as RiskStatus]}
+                                        stroke="#fff"
+                                    />
                                     ))}
+                                    <LabelList content={renderStatusLabel} />
                                 </Pie>
-                                <Tooltip />
-                                <Legend />
+                                <Tooltip content={tooltipContent} />
+                                <Legend formatter={(value) => `${value} (${summary.statusData.find((s) => s.name === value)?.value ?? 0})`} />
                             </PieChart>
                         </ResponsiveContainer>
+                        </div>
                     </CardContent>
                 </Card>
             </div>
@@ -191,8 +306,9 @@ export default function RisksPage() {
                                     <CartesianGrid strokeDasharray="3 3" horizontal={false} />
                                     <XAxis type="number" allowDecimals={false} />
                                     <YAxis type="category" dataKey="name" width={80} />
-                                    <Tooltip cursor={{ fill: 'hsl(var(--muted))' }} />
+                                    <Tooltip cursor={{ fill: 'hsl(var(--muted))' }} content={tooltipContent} />
                                     <Bar dataKey="value" name="Jumlah Risiko" barSize={30}>
+                                        <LabelList content={renderLevelLabel} />
                                         {summary.levelData.map((entry, index) => (
                                             <Cell key={`cell-${index}`} fill={COLORS[entry.name as RiskLevel]} />
                                         ))}
@@ -200,6 +316,16 @@ export default function RisksPage() {
                                 </BarChart>
                             </ResponsiveContainer>
                             </div>
+                            <table className="mt-4 text-sm">
+                              <tbody>
+                                {summary.levelData.map((d) => (
+                                  <tr key={d.name}>
+                                    <td className="pr-2">{d.name}</td>
+                                    <td>{d.value}</td>
+                                  </tr>
+                                ))}
+                              </tbody>
+                            </table>
                         </div>
                         <div className="lg:col-span-3">
                             <h3 className="text-lg font-semibold mb-2">Status Penyelesaian Risiko</h3>
@@ -210,22 +336,35 @@ export default function RisksPage() {
                                         data={summary.statusData}
                                         cx="50%"
                                         cy="50%"
-                                        labelLine={false}
                                         outerRadius={80}
-                                        fill="#8884d8"
                                         dataKey="value"
                                         nameKey="name"
-                                        label={({ name, percent }) => `${name} (${(percent * 100).toFixed(0)}%)`}
+                                        paddingAngle={2}
                                     >
                                         {summary.statusData.map((entry, index) => (
-                                        <Cell key={`cell-${index}`} fill={STATUS_COLORS[entry.name as RiskStatus]} />
+                                        <Cell
+                                            key={`cell-${index}`}
+                                            fill={STATUS_COLORS[entry.name as RiskStatus]}
+                                            stroke="#fff"
+                                        />
                                         ))}
+                                        <LabelList content={renderStatusLabel} />
                                     </Pie>
-                                    <Tooltip />
-                                    <Legend />
+                                    <Tooltip content={tooltipContent} />
+                                    <Legend formatter={(value) => `${value} (${summary.statusData.find((s) => s.name === value)?.value ?? 0})`} />
                                 </PieChart>
                             </ResponsiveContainer>
                             </div>
+                            <table className="mt-4 text-sm">
+                              <tbody>
+                                {summary.statusData.map((d) => (
+                                  <tr key={d.name}>
+                                    <td className="pr-2">{d.name}</td>
+                                    <td>{d.value}</td>
+                                  </tr>
+                                ))}
+                              </tbody>
+                            </table>
                         </div>
                     </div>
                 </div>

--- a/src/components/organisms/report-preview-dialog.copy.ts
+++ b/src/components/organisms/report-preview-dialog.copy.ts
@@ -1,0 +1,37 @@
+export const copyReport = async (
+  content: HTMLDivElement | null,
+  title?: string,
+  description?: string
+) => {
+  if (!content) return Promise.reject("No content")
+
+  const htmlParts: string[] = []
+  const textParts: string[] = []
+
+  if (title) {
+    htmlParts.push(`<h1>${title}</h1>`)
+    textParts.push(title)
+  }
+  if (description) {
+    htmlParts.push(`<p>${description}</p>`)
+    textParts.push(description)
+  }
+
+  htmlParts.push(content.innerHTML)
+  textParts.push(content.innerText)
+
+  const html = htmlParts.join("\n")
+  const text = textParts.join("\n\n")
+
+  try {
+    await navigator.clipboard.write([
+      new ClipboardItem({
+        "text/html": new Blob([html], { type: "text/html" }),
+        "text/plain": new Blob([text], { type: "text/plain" }),
+      }),
+    ])
+  } catch {
+    await navigator.clipboard.writeText(text)
+  }
+}
+

--- a/src/components/organisms/report-preview-dialog.print.ts
+++ b/src/components/organisms/report-preview-dialog.print.ts
@@ -32,18 +32,19 @@ export const printReport = (
             .no-print { display: none; }
           }
           body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif; }
-          table { border-collapse: collapse; width: 100%; font-size: 11px; }
-          th, td { border: 1px solid #e2e8f0; padding: 6px; text-align: left; }
+          table { border-collapse: collapse; width: 100%; font-size: 11px; table-layout: auto; }
+          th, td { border: 1px solid #e2e8f0; padding: 6px; text-align: left; vertical-align: top; word-break: break-word; }
           th { background-color: #f1f5f9; }
           .print-page { page-break-before: always; padding-top: 2rem; }
           .print-page:first-child { page-break-before: avoid; padding-top: 0; }
+          .print-container, .print-container * { max-width: 100%; overflow: visible !important; }
           h1 { font-size: 24px; font-weight: bold; margin-bottom: 8px; }
           h2 { font-size: 20px; font-weight: bold; margin-bottom: 12px; }
           h3 { font-size: 16px; font-weight: bold; margin-bottom: 8px; }
         </style>
       </head>
       <body>
-        <div class="p-4">
+        <div class="p-4 print-container">
            <h1>${title || 'Laporan'}</h1>
            <p>${description || ''}</p>
            <div class="mt-8">

--- a/src/components/organisms/report-preview-dialog.tsx
+++ b/src/components/organisms/report-preview-dialog.tsx
@@ -6,11 +6,13 @@ import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } f
 import { Button } from "@/components/ui/button"
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table"
 import { flexRender, getCoreRowModel, useReactTable } from "@tanstack/react-table"
-import { Download } from "lucide-react"
+import { Download, Copy } from "lucide-react"
 
 import { ReportPreviewDialogProps } from "./report-preview-dialog.interface"
 import { printReport } from "./report-preview-dialog.print"
+import { copyReport } from "./report-preview-dialog.copy"
 import { defaultFilterFns } from "@/lib/default-filter-fns"
+import { useToast } from "@/hooks/use-toast"
 
 export function ReportPreviewDialog({
   open,
@@ -33,6 +35,7 @@ export function ReportPreviewDialog({
   })
 
   const contentRef = React.useRef<HTMLDivElement>(null)
+  const { toast } = useToast()
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -105,9 +108,30 @@ export function ReportPreviewDialog({
           <Button variant="outline" onClick={() => onOpenChange(false)}>
             Tutup
           </Button>
+          <Button
+            variant="outline"
+            onClick={async () => {
+              try {
+                await copyReport(contentRef.current, title, description)
+                toast({
+                  title: "Laporan Disalin",
+                  description: "Konten laporan siap ditempel ke Word.",
+                })
+              } catch {
+                toast({
+                  title: "Gagal Menyalin",
+                  description: "Terjadi kesalahan saat menyalin laporan.",
+                  variant: "destructive",
+                })
+              }
+            }}
+          >
+            <Copy className="mr-2 h-4 w-4" />
+            Salin Teks
+          </Button>
           <Button onClick={() => printReport(contentRef.current, title, description)}>
-              <Download className="mr-2 h-4 w-4" />
-              Cetak / Unduh PDF
+            <Download className="mr-2 h-4 w-4" />
+            Cetak / Unduh PDF
           </Button>
         </div>
       </DialogContent>

--- a/src/components/organisms/risk-form.tsx
+++ b/src/components/organisms/risk-form.tsx
@@ -121,6 +121,11 @@ export function RiskForm({ setOpen, riskToEdit }: RiskFormProps) {
             dueDate: riskToEdit.dueDate ? new Date(riskToEdit.dueDate) : undefined,
             residualConsequence: riskToEdit.residualConsequence || 0,
             residualLikelihood: riskToEdit.residualLikelihood || 0,
+            actionPlan: riskToEdit.actionPlan ?? "",
+            reportNotes: riskToEdit.reportNotes ?? "",
+            description: riskToEdit.description ?? "",
+            cause: riskToEdit.cause ?? "",
+            pic: riskToEdit.pic ?? "",
         } : {
             unit: currentUser?.unit,
             description: "",
@@ -212,7 +217,7 @@ export function RiskForm({ setOpen, riskToEdit }: RiskFormProps) {
                             <FormItem>
                             <FormLabel>Deskripsi Risiko/Kejadian</FormLabel>
                             <FormControl>
-                                <Textarea placeholder="Jelaskan risiko potensial atau aktual yang terjadi" {...field} />
+                                <Textarea placeholder="Jelaskan risiko potensial atau aktual yang terjadi" {...field} value={field.value ?? ''} />
                             </FormControl>
                             <FormMessage />
                             </FormItem>
@@ -226,7 +231,7 @@ export function RiskForm({ setOpen, riskToEdit }: RiskFormProps) {
                             <FormItem>
                             <FormLabel>Penyebab (Akar Masalah)</FormLabel>
                             <FormControl>
-                                <Textarea placeholder="Jelaskan penyebab utama dari risiko/kejadian ini" {...field} />
+                                <Textarea placeholder="Jelaskan penyebab utama dari risiko/kejadian ini" {...field} value={field.value ?? ''} />
                             </FormControl>
                             <FormMessage />
                             </FormItem>
@@ -364,7 +369,7 @@ export function RiskForm({ setOpen, riskToEdit }: RiskFormProps) {
                             <FormItem>
                             <FormLabel>Rencana Aksi & Tindak Lanjut</FormLabel>
                             <FormControl>
-                                <Textarea placeholder="Jelaskan langkah-langkah yang akan diambil untuk menangani risiko ini..." {...field} />
+                                <Textarea placeholder="Jelaskan langkah-langkah yang akan diambil untuk menangani risiko ini..." {...field} value={field.value ?? ''} />
                             </FormControl>
                             <FormMessage />
                             </FormItem>
@@ -506,7 +511,7 @@ export function RiskForm({ setOpen, riskToEdit }: RiskFormProps) {
                             <FormItem>
                                 <FormLabel>Laporan Singkat / Monev</FormLabel>
                                 <FormControl>
-                                    <Textarea placeholder="Isi laporan singkat atau hasil monitoring dan evaluasi di sini" {...field} />
+                                    <Textarea placeholder="Isi laporan singkat atau hasil monitoring dan evaluasi di sini" {...field} value={field.value ?? ''} />
                                 </FormControl>
                                 <FormMessage />
                             </FormItem>

--- a/src/components/organisms/risk-table.tsx
+++ b/src/components/organisms/risk-table.tsx
@@ -249,9 +249,10 @@ const columns: ColumnDef<Risk>[] = [
     header: () => <div className="text-center">Status & Batas Waktu</div>,
     cell: ({ row }) => {
         const risk = row.original;
-        const status = risk.status;
+        const rawStatus = risk.status as string;
+        const status = (rawStatus === 'InProgress' ? 'In Progress' : rawStatus) as RiskStatus;
         const dueDate = risk.dueDate;
-        
+
         return (
             <div className="text-center flex flex-col items-center justify-center gap-2">
                 <Badge className={cn("text-sm capitalize", getStatusClass(status))}>{status}</Badge>
@@ -260,7 +261,9 @@ const columns: ColumnDef<Risk>[] = [
         )
     },
     filterFn: (row, id, value) => {
-      return value.includes(row.getValue(id))
+      const cellValue = row.getValue(id)
+      const normalized = cellValue === 'InProgress' ? 'In Progress' : cellValue
+      return value.includes(normalized)
     },
     size: 150,
   },

--- a/src/lib/copy-chart.ts
+++ b/src/lib/copy-chart.ts
@@ -1,0 +1,92 @@
+type ChartDetail = {
+  name: string
+  value: number
+  color?: string
+  colorName?: string
+}
+
+export async function copyChartImage(
+  node: HTMLElement | null,
+  details?: ChartDetail[],
+) {
+  if (!node) return Promise.reject("No element")
+  const svg = node.querySelector("svg") as SVGSVGElement | null
+  if (!svg) return Promise.reject("No chart")
+
+  // clone SVG and inline computed styles so CSS variables resolve correctly
+  const clone = svg.cloneNode(true) as SVGSVGElement
+  const originalElements = svg.querySelectorAll("*")
+  const clonedElements = clone.querySelectorAll("*")
+  originalElements.forEach((el, i) => {
+    const computed = getComputedStyle(el)
+    const cloneEl = clonedElements[i] as HTMLElement
+    cloneEl.setAttribute("fill", computed.fill)
+    cloneEl.setAttribute("stroke", computed.stroke)
+    cloneEl.setAttribute("stroke-width", computed.strokeWidth)
+    cloneEl.setAttribute("font-size", computed.fontSize)
+    cloneEl.setAttribute("font-family", computed.fontFamily)
+  })
+
+  const { width, height } = svg.getBoundingClientRect()
+  clone.setAttribute("width", width.toString())
+  clone.setAttribute("height", height.toString())
+  clone.setAttribute("viewBox", `0 0 ${width} ${height}`)
+
+  const serializer = new XMLSerializer()
+  const svgString = serializer.serializeToString(clone)
+  const canvas = document.createElement("canvas")
+  canvas.width = width
+  canvas.height = height
+  const ctx = canvas.getContext("2d")
+  if (!ctx) return Promise.reject("No context")
+
+  // set white background so transparent areas don't become black
+  ctx.fillStyle = "#fff"
+  ctx.fillRect(0, 0, width, height)
+
+  const img = new Image()
+  const svgBlob = new Blob([svgString], { type: "image/svg+xml;charset=utf-8" })
+  const url = URL.createObjectURL(svgBlob)
+
+  await new Promise<void>((resolve, reject) => {
+    img.onload = () => {
+      ctx.drawImage(img, 0, 0)
+      URL.revokeObjectURL(url)
+      resolve()
+    }
+    img.onerror = () => {
+      URL.revokeObjectURL(url)
+      reject(new Error("Failed to load image"))
+    }
+    img.src = url
+  })
+
+  const blob = await new Promise<Blob | null>((resolve) => canvas.toBlob(resolve))
+  if (!blob) return Promise.reject("No blob")
+
+  const item: Record<string, Blob> = { [blob.type]: blob }
+
+  if (details && details.length > 0) {
+    const text = details
+      .map((d) =>
+        d.colorName ? `${d.name} (${d.colorName}): ${d.value}` : `${d.name}: ${d.value}`,
+      )
+      .join("\n")
+    const dataUrl = canvas.toDataURL("image/png")
+    const tableRows = details
+      .map((d) => {
+        const colorSwatch = d.color
+          ? `<span style="display:inline-block;width:12px;height:12px;background:${d.color};margin-right:4px;"></span>`
+          : ""
+        const label = d.colorName ? `${d.name} (${d.colorName})` : d.name
+        return `<tr><td>${colorSwatch}${label}</td><td>${d.value}</td></tr>`
+      })
+      .join("")
+    const html = `<div><img src="${dataUrl}"/><table>${tableRows}</table></div>`
+
+    item["text/plain"] = new Blob([text], { type: "text/plain" })
+    item["text/html"] = new Blob([html], { type: "text/html" })
+  }
+
+  await navigator.clipboard.write([new ClipboardItem(item)])
+}


### PR DESCRIPTION
## Summary
- allow copying report content to clipboard
- provide button in risk report preview for easy Word pasting
- ensure printed tables expand to full width
- add copy buttons to dashboard risk charts for image clipboard export
- implement utility to convert chart SVGs into clipboard-ready images
- display chart values and include summary tables so copied reports remain readable without color
- inline computed styles so copied chart images keep their original colors
- separate and label status pie slices for clearer visuals in reports and copied charts
- handle missing pie chart payload to prevent runtime errors on the risks page
- copy chart details along with chart image for clearer context
- fix status aggregation to avoid 'InProgress (NaN)' and color slices red/amber/green for clarity
- normalize fetched risks so PICs render as names and 'InProgress' statuses show as 'In Progress'
- default textarea values to empty strings to avoid React warnings
- include color names and swatches in copied pie chart details
- color chart labels and tooltips to match their corresponding bar or slice

## Testing
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_b_68c378123f58832483a9c01de692b87e