### PR TITLE
Improve risk status pie chart label visibility

### DIFF
--- a/src/app/dashboard/risks/page.tsx
+++ b/src/app/dashboard/risks/page.tsx
@@ -104,6 +104,7 @@ export default function RisksPage() {
         value,
         color: STATUS_COLORS[name as RiskStatus],
         colorName: STATUS_COLOR_NAMES[name as RiskStatus],
+        fill: STATUS_COLORS[name as RiskStatus],
       })),
     }
   }, [risks])
@@ -265,7 +266,7 @@ export default function RisksPage() {
                     {summary.statusData.map((entry, index) => (
                       <Cell
                         key={`cell-${index}`}
-                        fill={STATUS_COLORS[entry.name as RiskStatus]}
+                        fill={entry.fill}
                         stroke="#fff"
                       />
                     ))}
@@ -275,7 +276,6 @@ export default function RisksPage() {
                       formatter={(val: number, entry: any) =>
                         `${entry?.name ? `${entry.name}: ` : ""}${val}`
                       }
-                      fill="hsl(var(--foreground))"
                     />
                   </Pie>
                   <Tooltip />
@@ -387,7 +387,7 @@ export default function RisksPage() {
                       {summary.statusData.map((entry, index) => (
                         <Cell
                           key={`cell-${index}`}
-                          fill={STATUS_COLORS[entry.name as RiskStatus]}
+                          fill={entry.fill}
                           stroke="#fff"
                         />
                       ))}
@@ -397,7 +397,6 @@ export default function RisksPage() {
                         formatter={(val: number, entry: any) =>
                           `${entry?.name ? `${entry.name}: ` : ""}${val}`
                         }
-                        fill="hsl(var(--foreground))"
                       />
                     </Pie>
                     <Tooltip />


### PR DESCRIPTION
## Summary
- color risk status pie chart labels with their corresponding slice colors
- remove hardcoded foreground color to enhance readability

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_b_68c39d5c3a008324877ae023ced60b4f