### PR TITLE
Fix sidebar submenu toggle behavior

### DIFF
--- a/src/components/dashboard-layout-client.tsx
+++ b/src/components/dashboard-layout-client.tsx
@@ -170,8 +170,34 @@ export default function DashboardClientLayout({
   const currentPage = breadcrumbPath[breadcrumbPath.length - 1];
 
   const [openMenus, setOpenMenus] = React.useState<{ [key: string]: boolean }>(
-    {}
+    () => {
+      const initialState: { [key: string]: boolean } = {};
+
+      for (const item of breadcrumbPath) {
+        if (item.subItems) {
+          initialState[item.label] = true;
+        }
+      }
+
+      return initialState;
+    },
   );
+
+  React.useEffect(() => {
+    setOpenMenus(prev => {
+      let hasChanges = false;
+      const nextState = { ...prev };
+
+      for (const item of breadcrumbPath) {
+        if (item.subItems && !nextState[item.label]) {
+          nextState[item.label] = true;
+          hasChanges = true;
+        }
+      }
+
+      return hasChanges ? nextState : prev;
+    });
+  }, [breadcrumbPath]);
   const logoutNavItem = {
     label: "Logout",
     icon: LogOut,

--- a/src/components/molecules/nav-item.tsx
+++ b/src/components/molecules/nav-item.tsx
@@ -21,12 +21,6 @@ const NavSubMenu = ({ item, openMenus, setOpenMenus, isSubItem }: NavItemProps) 
   const isParentActive = useActivePath(item)
   const isOpen = openMenus[label] || false
 
-  React.useEffect(() => {
-    if (isParentActive && !isOpen) {
-      setOpenMenus(prev => ({ ...prev, [label]: true }))
-    }
-  }, [isParentActive, isOpen, label, setOpenMenus])
-
   const handleToggle = React.useCallback(() => {
     setOpenMenus(prev => ({
       ...prev,


### PR DESCRIPTION
## Summary
- initialize sidebar open menu state based on the current breadcrumb path
- ensure breadcrumb changes automatically expand relevant menu groups without overriding manual toggles
- remove per-item effect that forced submenu reopening when the current page stayed active

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_b_68ccc5e134a48324acd99fdb1e59b07d