### PR TITLE
Centralize indicator dashboard text constants

### DIFF
--- a/src/app/dashboard/imp-rs/page.tsx
+++ b/src/app/dashboard/imp-rs/page.tsx
@@ -3,12 +3,14 @@
 
 import * as React from "react"
 import { IndicatorDashboardTemplate } from "@/components/templates/indicator-dashboard-template"
+import { INDICATOR_TEXTS } from "@/lib/constants"
 
 export default function ImpRsPage() {
+  const category = "IMP-RS" as const
   return (
     <IndicatorDashboardTemplate
-      category="IMP-RS"
-      pageTitle="Indikator Mutu Prioritas RS (IMP-RS)"
+      category={category}
+      pageTitle={INDICATOR_TEXTS.dashboard.pageTitles[category]}
     />
   )
 }

--- a/src/app/dashboard/impu/page.tsx
+++ b/src/app/dashboard/impu/page.tsx
@@ -3,12 +3,14 @@
 
 import * as React from "react"
 import { IndicatorDashboardTemplate } from "@/components/templates/indicator-dashboard-template"
+import { INDICATOR_TEXTS } from "@/lib/constants"
 
 export default function ImpuPage() {
+  const category = "IMPU" as const
   return (
     <IndicatorDashboardTemplate
-      category="IMPU"
-      pageTitle="Indikator Mutu Prioritas Unit (IMPU)"
+      category={category}
+      pageTitle={INDICATOR_TEXTS.dashboard.pageTitles[category]}
     />
   )
 }

--- a/src/app/dashboard/reports/page.tsx
+++ b/src/app/dashboard/reports/page.tsx
@@ -10,6 +10,7 @@ import { useIndicatorStore, IndicatorCategory, SubmittedIndicator, Indicator } f
 import { ReportPreviewDialog } from "@/components/organisms/report-preview-dialog"
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table"
 import { Badge } from "@/components/ui/badge"
+import { INDICATOR_TEXTS } from "@/lib/constants"
 
 type YearlyReportData = {
   no: number
@@ -18,12 +19,7 @@ type YearlyReportData = {
   months: (string | null)[]
 }
 
-const categoryLabels: Record<IndicatorCategory, string> = {
-  INM: "Indikator Nasional Mutu",
-  'IMP-RS': "Indikator Mutu Prioritas RS",
-  IMPU: "Indikator Mutu Prioritas Unit",
-  SPM: "Standar Pelayanan Minimal"
-}
+const categoryLabels: Record<IndicatorCategory, string> = INDICATOR_TEXTS.dashboard.categoryLabels
 
 const ReportTable = ({ title, data }: { title: string, data: YearlyReportData[] }) => {
   const months = ["Jan", "Feb", "Mar", "Apr", "Mei", "Jun", "Jul", "Agu", "Sep", "Okt", "Nov", "Des"];

--- a/src/app/dashboard/spm/page.tsx
+++ b/src/app/dashboard/spm/page.tsx
@@ -3,12 +3,14 @@
 
 import * as React from "react"
 import { IndicatorDashboardTemplate } from "@/components/templates/indicator-dashboard-template"
+import { INDICATOR_TEXTS } from "@/lib/constants"
 
 export default function SpmPage() {
+  const category = "SPM" as const
   return (
     <IndicatorDashboardTemplate
-      category="SPM"
-      pageTitle="Standar Pelayanan Minimal (SPM)"
+      category={category}
+      pageTitle={INDICATOR_TEXTS.dashboard.pageTitles[category]}
     />
   )
 }

--- a/src/components/organisms/indicator-chart-card.tsx
+++ b/src/components/organisms/indicator-chart-card.tsx
@@ -25,6 +25,7 @@ import {
 } from "@/components/ui/card"
 import { format } from "date-fns"
 import { id as IndonesianLocale } from "date-fns/locale"
+import { INDICATOR_TEXTS } from "@/lib/constants"
 
 type IndicatorChartCardProps = {
   chartData: any[]
@@ -54,9 +55,9 @@ export function IndicatorChartCard({
       return (
         <div className="p-2 bg-background border rounded-md shadow-lg">
           <p className="font-bold text-foreground">{formattedDate}</p>
-          <p className="text-sm text-primary">{`Capaian: ${data.Capaian}${data.unit}`}</p>
+          <p className="text-sm text-primary">{`${INDICATOR_TEXTS.chartCard.tooltip.capaian}: ${data.Capaian}${data.unit}`}</p>
           {data.Standar && (
-            <p className="text-sm text-destructive">{`Standar: ${data.Standar}${data.unit}`}</p>
+            <p className="text-sm text-destructive">{`${INDICATOR_TEXTS.chartCard.tooltip.standar}: ${data.Standar}${data.unit}`}</p>
           )}
         </div>
       )
@@ -100,7 +101,7 @@ export function IndicatorChartCard({
         >
           <LabelList dataKey="label" position="top" />
         </MainChartElement>
-        {chartType === "line" && selectedIndicator !== "Semua Indikator" && chartData.some(d => d.Standar) && (
+        {chartType === "line" && selectedIndicator !== INDICATOR_TEXTS.defaults.allIndicators && chartData.some(d => d.Standar) && (
           <Line
             type="monotone"
             dataKey="Standar"
@@ -117,7 +118,7 @@ export function IndicatorChartCard({
   return (
     <Card>
       <CardHeader>
-        <CardTitle>Capaian Indikator Terkini</CardTitle>
+        <CardTitle>{INDICATOR_TEXTS.chartCard.title}</CardTitle>
         <CardDescription>{description}</CardDescription>
       </CardHeader>
       <CardContent className="pl-2">
@@ -126,7 +127,7 @@ export function IndicatorChartCard({
             renderChart()
           ) : (
             <div className="flex items-center justify-center h-full text-muted-foreground">
-              Tidak cukup data untuk menampilkan grafik.
+              {INDICATOR_TEXTS.chartCard.emptyState}
             </div>
           )}
         </ResponsiveContainer>

--- a/src/components/organisms/indicator-filter-card.tsx
+++ b/src/components/organisms/indicator-filter-card.tsx
@@ -25,11 +25,15 @@ import { Calendar } from "@/components/ui/calendar"
 import { format } from "date-fns"
 import { id as IndonesianLocale } from "date-fns/locale"
 import { cn } from "@/lib/utils"
-import { HOSPITAL_UNITS } from "@/lib/constants"
+import { HOSPITAL_UNITS, INDICATOR_TEXTS } from "@/lib/constants"
 import type { FilterType } from "@/lib/indicator-utils"
 import type { IndicatorFilterCardProps } from "./indicator-filter-card.type"
 
-const unitOptions = [{ value: "Semua Unit", label: "Semua Unit" }, ...HOSPITAL_UNITS.map(u => ({ value: u, label: u }))];
+const allUnitsLabel = INDICATOR_TEXTS.defaults.allUnits
+const unitOptions = [
+  { value: allUnitsLabel, label: allUnitsLabel },
+  ...HOSPITAL_UNITS.map(u => ({ value: u, label: u })),
+]
 
 export function IndicatorFilterCard({
   userIsCentral,
@@ -59,9 +63,17 @@ export function IndicatorFilterCard({
       return (
         <Popover>
           <PopoverTrigger asChild>
-            <Button variant={"outline"} className={cn("w-[200px] justify-start text-left font-normal", !selectedDate && "text-muted-foreground")}>
+            <Button
+              variant={"outline"}
+              className={cn(
+                "w-[200px] justify-start text-left font-normal",
+                !selectedDate && "text-muted-foreground"
+              )}
+            >
               <CalendarIcon className="mr-2 h-4 w-4" />
-              {selectedDate ? format(selectedDate, "PPP", { locale: IndonesianLocale }) : <span>Pilih tanggal</span>}
+              {selectedDate
+                ? format(selectedDate, "PPP", { locale: IndonesianLocale })
+                : <span>{INDICATOR_TEXTS.filterCard.placeholders.date}</span>}
             </Button>
           </PopoverTrigger>
           <PopoverContent className="w-auto p-0"><Calendar mode="single" selected={selectedDate} onSelect={(date) => date && setSelectedDate(date)} initialFocus disabled={{ after: new Date() }} month={selectedDate} /></PopoverContent>
@@ -100,39 +112,49 @@ export function IndicatorFilterCard({
       <CardHeader>
         <CardTitle>
           <Filter className="mr-2 h-5 w-5 inline-block" />
-          Filter & Tampilan Data
+          {INDICATOR_TEXTS.filterCard.title}
         </CardTitle>
-        <CardDescription>Gunakan filter di bawah untuk menampilkan data yang lebih spesifik.</CardDescription>
+        <CardDescription>{INDICATOR_TEXTS.filterCard.description}</CardDescription>
       </CardHeader>
       <CardContent className="space-y-6">
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
           <div className="space-y-2">
-            <Label>Filter Data</Label>
+            <Label>{INDICATOR_TEXTS.filterCard.labels.filter}</Label>
             <div className="space-y-2">
               {userIsCentral && (
-                <Combobox options={unitOptions} value={selectedUnit} onSelect={setSelectedUnit} placeholder="Pilih unit..." searchPlaceholder="Cari unit..." />
+                <Combobox
+                  options={unitOptions}
+                  value={selectedUnit}
+                  onSelect={setSelectedUnit}
+                  placeholder={INDICATOR_TEXTS.filterCard.placeholders.unit}
+                  searchPlaceholder={INDICATOR_TEXTS.filterCard.placeholders.unitSearch}
+                />
               )}
               {uniqueIndicatorNames.length > 1 && (
-                <Combobox options={uniqueIndicatorNames} value={selectedIndicator} onSelect={setSelectedIndicator} placeholder="Pilih indikator..." searchPlaceholder="Cari indikator..." />
+                <Combobox
+                  options={uniqueIndicatorNames}
+                  value={selectedIndicator}
+                  onSelect={setSelectedIndicator}
+                  placeholder={INDICATOR_TEXTS.filterCard.placeholders.indicator}
+                  searchPlaceholder={INDICATOR_TEXTS.filterCard.placeholders.indicatorSearch}
+                />
               )}
             </div>
           </div>
           <div className="space-y-2">
-            <Label>Tampilan & Rentang Waktu</Label>
+            <Label>{INDICATOR_TEXTS.filterCard.labels.displayRange}</Label>
             <div className="flex flex-col sm:flex-row gap-2">
               <div className="flex-grow">
                 <Select value={filterType} onValueChange={v => setFilterType(v as FilterType)}>
-                  <SelectTrigger><SelectValue placeholder="Pilih rentang..." /></SelectTrigger>
+                  <SelectTrigger>
+                    <SelectValue placeholder={INDICATOR_TEXTS.filterCard.placeholders.range} />
+                  </SelectTrigger>
                   <SelectContent>
-                    <SelectItem value="this_month">Bulan Ini</SelectItem>
-                    <SelectItem value="7d">7 Hari Terakhir</SelectItem>
-                    <SelectItem value="30d">30 Hari Terakhir</SelectItem>
-                    <SelectItem value="3m">3 Bulan Terakhir</SelectItem>
-                    <SelectItem value="6m">6 Bulan Terakhir</SelectItem>
-                    <SelectItem value="1y">1 Tahun Terakhir</SelectItem>
-                    <SelectItem value="daily">Harian (Custom)</SelectItem>
-                    <SelectItem value="monthly">Bulanan (Custom)</SelectItem>
-                    <SelectItem value="yearly">Tahunan (Custom)</SelectItem>
+                    {INDICATOR_TEXTS.filterCard.filterTypeOptions.map(option => (
+                      <SelectItem key={option.value} value={option.value}>
+                        {option.label}
+                      </SelectItem>
+                    ))}
                   </SelectContent>
                 </Select>
               </div>
@@ -149,7 +171,7 @@ export function IndicatorFilterCard({
           <div className="space-y-2">
             {showCustomFilterInput && (
               <>
-                <Label>Filter Kustom</Label>
+                <Label>{INDICATOR_TEXTS.filterCard.labels.custom}</Label>
                 <div>{renderFilterInput()}</div>
               </>
             )}

--- a/src/components/organisms/indicator-report-table.tsx
+++ b/src/components/organisms/indicator-report-table.tsx
@@ -33,6 +33,7 @@ import { categoryFilter } from "./indicator-report-table/table-filters.utils"
 import { format, parseISO, isValid } from "date-fns"
 import { id as IndonesianLocale } from "date-fns/locale"
 import { Tooltip, TooltipContent, TooltipTrigger } from "../ui/tooltip"
+import { INDICATOR_TEXTS } from "@/lib/constants"
 
 type IndicatorReportTableProps = {
   indicators: Indicator[]
@@ -60,7 +61,7 @@ export function IndicatorReportTable({
             variant="ghost"
             onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}
           >
-            Indikator <ArrowUpDown className="ml-2 h-4 w-4" />
+            {INDICATOR_TEXTS.reportTable.headers.indicator} <ArrowUpDown className="ml-2 h-4 w-4" />
           </Button>
         ),
         cell: ({ row }) => (
@@ -69,7 +70,7 @@ export function IndicatorReportTable({
       },
       {
         accessorKey: "category",
-        header: "Kategori",
+        header: INDICATOR_TEXTS.reportTable.headers.category,
         cell: ({ row }) => (
           <Badge variant="outline">{row.getValue("category")}</Badge>
         ),
@@ -82,14 +83,14 @@ export function IndicatorReportTable({
             variant="ghost"
             onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}
           >
-            Periode <ArrowUpDown className="ml-2 h-4 w-4" />
+            {INDICATOR_TEXTS.reportTable.headers.period} <ArrowUpDown className="ml-2 h-4 w-4" />
           </Button>
         ),
         cell: ({ row }) => {
           const dateValue = row.getValue("period") as string
           const parsedDate = parseISO(dateValue)
           if (!isValid(parsedDate)) {
-            return <span>Tanggal Invalid</span>
+            return <span>{INDICATOR_TEXTS.reportTable.invalidDate}</span>
           }
           return (
             <div>
@@ -100,7 +101,7 @@ export function IndicatorReportTable({
       },
       {
         accessorKey: "ratio",
-        header: () => <div className="text-right">Capaian</div>,
+        header: () => <div className="text-right">{INDICATOR_TEXTS.reportTable.headers.ratio}</div>,
         cell: ({ row }) => {
           const ratio = row.getValue("ratio") as string
           const {
@@ -127,13 +128,13 @@ export function IndicatorReportTable({
               </TooltipTrigger>
               <TooltipContent>
                 <div className="space-y-1 p-1">
-                  <p className="font-bold text-base">Rincian Perhitungan</p>
+                  <p className="font-bold text-base">{INDICATOR_TEXTS.reportTable.tooltip.title}</p>
                   <p>
-                    <span className="font-semibold">Formula:</span>{" "}
+                    <span className="font-semibold">{INDICATOR_TEXTS.reportTable.tooltip.formulaLabel}</span>{" "}
                     {formulaText}
                   </p>
                   <p>
-                    <span className="font-semibold">Substitusi:</span>{" "}
+                    <span className="font-semibold">{INDICATOR_TEXTS.reportTable.tooltip.substitutionLabel}</span>{" "}
                     {substitutionText}
                   </p>
                 </div>
@@ -144,7 +145,7 @@ export function IndicatorReportTable({
       },
       {
         accessorKey: "standard",
-        header: () => <div className="text-right">Standar</div>,
+        header: () => <div className="text-right">{INDICATOR_TEXTS.reportTable.headers.standard}</div>,
         cell: ({ row }) => {
           const standard = row.original.standard
           const unit = row.original.standardUnit
@@ -153,7 +154,7 @@ export function IndicatorReportTable({
       },
       {
         accessorKey: "status",
-        header: () => <div className="text-center">Status</div>,
+        header: () => <div className="text-center">{INDICATOR_TEXTS.reportTable.headers.status}</div>,
         cell: ({ row }) => {
           const status = row.getValue("status") as Indicator["status"]
           return (
@@ -171,7 +172,7 @@ export function IndicatorReportTable({
       },
       {
         id: "actions",
-        header: () => <div className="text-center">Aksi</div>,
+        header: () => <div className="text-center">{INDICATOR_TEXTS.reportTable.headers.actions}</div>,
         cell: ({ row }) => <ActionsCell row={row} onEdit={onEdit} />,
       },
     ],
@@ -255,7 +256,7 @@ export function IndicatorReportTable({
                   colSpan={columns.length}
                   className="h-24 text-center"
                 >
-                  Tidak ada hasil.
+                  {INDICATOR_TEXTS.reportTable.emptyState}
                 </TableCell>
               </TableRow>
             )}
@@ -264,8 +265,10 @@ export function IndicatorReportTable({
       </div>
       <div className="flex items-center justify-end space-x-2 py-4">
         <div className="flex-1 text-sm text-muted-foreground">
-          Menampilkan {table.getFilteredRowModel().rows.length} dari{" "}
-          {indicators.length} total data.
+          {INDICATOR_TEXTS.reportTable.summary(
+            table.getFilteredRowModel().rows.length,
+            indicators.length
+          )}
         </div>
         <Button
           variant="outline"
@@ -273,7 +276,7 @@ export function IndicatorReportTable({
           onClick={() => table.previousPage()}
           disabled={!table.getCanPreviousPage()}
         >
-          Sebelumnya
+          {INDICATOR_TEXTS.reportTable.pagination.previous}
         </Button>
         <Button
           variant="outline"
@@ -281,7 +284,7 @@ export function IndicatorReportTable({
           onClick={() => table.nextPage()}
           disabled={!table.getCanNextPage()}
         >
-          Berikutnya
+          {INDICATOR_TEXTS.reportTable.pagination.next}
         </Button>
       </div>
     </div>

--- a/src/components/organisms/indicator-report.tsx
+++ b/src/components/organisms/indicator-report.tsx
@@ -16,7 +16,8 @@ import { useUserStore } from "@/store/user-store.tsx"
 import { CartesianGrid, LabelList, ResponsiveContainer, Tooltip as RechartsTooltip, XAxis, YAxis, LineChart, Line, Legend, Dot, BarChart, Bar } from "recharts"
 import { format, parseISO } from "date-fns"
 import { AnalysisTable } from "./analysis-table"
-import {centralRoles} from "@/store/central-roles.ts";
+import { centralRoles } from "@/store/central-roles.ts"
+import { INDICATOR_TEXTS } from "@/lib/constants"
 import type { IndicatorReportProps } from "./indicator-report.type"
 
 
@@ -70,8 +71,10 @@ export function IndicatorReport({ indicators, category, title, description, show
             return (
                 <div className="p-2 bg-background border rounded-md shadow-lg">
                     <p className="font-bold text-foreground">{formattedDate}</p>
-                    <p className="text-sm text-primary">{`Capaian: ${data.Capaian}`}</p>
-                    {data.Standar && <p className="text-sm text-destructive">{`Standar: ${data.Standar}`}</p>}
+                    <p className="text-sm text-primary">{`${INDICATOR_TEXTS.chartCard.tooltip.capaian}: ${data.Capaian}`}</p>
+                    {data.Standar && (
+                      <p className="text-sm text-destructive">{`${INDICATOR_TEXTS.chartCard.tooltip.standar}: ${data.Standar}`}</p>
+                    )}
                 </div>
             );
         }
@@ -97,7 +100,7 @@ export function IndicatorReport({ indicators, category, title, description, show
             </ResponsiveContainer>
         </div>
     ) : (
-        <p className="text-center text-sm text-muted-foreground">Tidak ada data untuk periode ini.</p>
+        <p className="text-center text-sm text-muted-foreground">{INDICATOR_TEXTS.report.emptyChart}</p>
     )
 
     const barChartComponent = chartData && chartData.length > 0 ? (
@@ -116,7 +119,7 @@ export function IndicatorReport({ indicators, category, title, description, show
             </ResponsiveContainer>
         </div>
     ) : (
-        <p className="text-center text-sm text-muted-foreground">Tidak ada data untuk periode ini.</p>
+        <p className="text-center text-sm text-muted-foreground">{INDICATOR_TEXTS.report.emptyChart}</p>
     )
 
 
@@ -126,9 +129,9 @@ export function IndicatorReport({ indicators, category, title, description, show
                 <CardHeader>
                     <div className="flex items-center justify-between">
                         <div>
-                            <CardTitle>{title || `Laporan Indikator ${category}`}</CardTitle>
+                            <CardTitle>{title || INDICATOR_TEXTS.report.defaultTitle(category)}</CardTitle>
                             <CardDescription>
-                                {description || `Riwayat data indikator ${category} yang telah diinput.`}
+                                {description || INDICATOR_TEXTS.report.defaultDescription(category)}
                                 {currentUser?.unit && !userCanSeeAll && ` (Unit: ${currentUser.unit})`}
                             </CardDescription>
                         </div>
@@ -137,7 +140,7 @@ export function IndicatorReport({ indicators, category, title, description, show
                                 {hasVerifiedIndicators ? (
                                     <Button onClick={handleAddNew} size="lg">
                                         <PlusCircle className="mr-2 h-4 w-4" />
-                                        Input Data Capaian
+                                        {INDICATOR_TEXTS.report.inputButton}
                                     </Button>
                                 ) : (
                                     <Tooltip>
@@ -145,12 +148,12 @@ export function IndicatorReport({ indicators, category, title, description, show
                                             <span tabIndex={0}>
                                                 <Button disabled size="lg">
                                                     <PlusCircle className="mr-2 h-4 w-4" />
-                                                    Input Data Capaian
+                                                    {INDICATOR_TEXTS.report.inputButton}
                                                 </Button>
                                             </span>
                                         </TooltipTrigger>
                                         <TooltipContent>
-                                            <p>Tidak ada indikator {category} yang diverifikasi untuk unit Anda.</p>
+                                            <p>{INDICATOR_TEXTS.report.tooltip(category)}</p>
                                         </TooltipContent>
                                     </Tooltip>
                                 )}
@@ -167,7 +170,7 @@ export function IndicatorReport({ indicators, category, title, description, show
                 onOpenChange={setIsPreviewOpen}
                 data={reportTableData || []}
                 columns={reportColumns || []}
-                title={`Laporan Capaian ${title || `Indikator ${category}`}`}
+                title={INDICATOR_TEXTS.report.previewTitle(title, category)}
                 description={reportDescription}
                 chartDescription={chartData && chartData.length > 0 ? reportDescription : undefined}
                 lineChart={lineChartComponent}

--- a/src/components/organisms/indicator-stat-cards.tsx
+++ b/src/components/organisms/indicator-stat-cards.tsx
@@ -8,6 +8,7 @@ import {
   CardTitle,
 } from "@/components/ui/card"
 import { Target, ThumbsUp, ThumbsDown } from "lucide-react"
+import { INDICATOR_TEXTS } from "@/lib/constants"
 
 type IndicatorStatCardsProps = {
   total: number
@@ -27,37 +28,37 @@ export function IndicatorStatCards({
       <Card>
         <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
           <CardTitle className="text-sm font-medium">
-            Total Indikator {category}
+            {INDICATOR_TEXTS.statCards.totalTitle(category)}
           </CardTitle>
           <Target className="h-4 w-4 text-muted-foreground" />
         </CardHeader>
         <CardContent>
           <div className="text-2xl font-bold">{total}</div>
           <p className="text-xs text-muted-foreground">
-            indikator yang dimonitor
+            {INDICATOR_TEXTS.statCards.totalDescription}
           </p>
         </CardContent>
       </Card>
       <Card>
         <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-          <CardTitle className="text-sm font-medium">Memenuhi Standar</CardTitle>
+          <CardTitle className="text-sm font-medium">{INDICATOR_TEXTS.statCards.meetingTitle}</CardTitle>
           <ThumbsUp className="h-4 w-4 text-muted-foreground" />
         </CardHeader>
         <CardContent>
           <div className="text-2xl font-bold">{meetingStandard}</div>
-          <p className="text-xs text-muted-foreground">capaian bulan ini</p>
+          <p className="text-xs text-muted-foreground">{INDICATOR_TEXTS.statCards.meetingDescription}</p>
         </CardContent>
       </Card>
       <Card>
         <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
           <CardTitle className="text-sm font-medium">
-            Tidak Memenuhi Standar
+            {INDICATOR_TEXTS.statCards.notMeetingTitle}
           </CardTitle>
           <ThumbsDown className="h-4 w-4 text-muted-foreground" />
         </CardHeader>
         <CardContent>
           <div className="text-2xl font-bold">{notMeetingStandard}</div>
-          <p className="text-xs text-muted-foreground">capaian bulan ini</p>
+          <p className="text-xs text-muted-foreground">{INDICATOR_TEXTS.statCards.notMeetingDescription}</p>
         </CardContent>
       </Card>
     </div>

--- a/src/components/templates/indicator-dashboard-template.tsx
+++ b/src/components/templates/indicator-dashboard-template.tsx
@@ -3,7 +3,6 @@
 "use client"
 
 import * as React from "react"
-import { parseISO } from "date-fns"
 
 import { useIndicatorStore, IndicatorCategory } from "@/store/indicator-store"
 import { useUserStore } from "@/store/user-store.tsx"
@@ -14,7 +13,8 @@ import { IndicatorFilterCard } from "@/components/organisms/indicator-filter-car
 import { IndicatorChartCard } from "@/components/organisms/indicator-chart-card"
 import { IndicatorReport } from "@/components/organisms/indicator-report"
 import { IndicatorStatCards } from "@/components/organisms/indicator-stat-cards"
-import {centralRoles} from "@/store/central-roles.ts";
+import { centralRoles } from "@/store/central-roles.ts"
+import { INDICATOR_TEXTS } from "@/lib/constants"
 
 type IndicatorDashboardTemplateProps = {
   category: IndicatorCategory
@@ -36,8 +36,13 @@ export function IndicatorDashboardTemplate({ category, pageTitle }: IndicatorDas
     // No unit filtering here, it will be handled by useIndicatorData hook
   }, [indicators, category])
 
-  const [selectedUnit, setSelectedUnit] = React.useState<string>(userIsCentral ? "Semua Unit" : currentUser?.unit || "Semua Unit")
-  const [selectedIndicator, setSelectedIndicator] = React.useState<string>("Semua Indikator")
+  const allUnitsLabel = INDICATOR_TEXTS.defaults.allUnits
+  const allIndicatorsLabel = INDICATOR_TEXTS.defaults.allIndicators
+
+  const [selectedUnit, setSelectedUnit] = React.useState<string>(
+    userIsCentral ? allUnitsLabel : currentUser?.unit || allUnitsLabel
+  )
+  const [selectedIndicator, setSelectedIndicator] = React.useState<string>(allIndicatorsLabel)
   const [filterType, setFilterType] = React.useState<FilterType>("this_month")
   const [selectedDate, setSelectedDate] = React.useState<Date>(new Date())
   const [chartType, setChartType] = React.useState<"line" | "bar">("line")
@@ -67,9 +72,10 @@ export function IndicatorDashboardTemplate({ category, pageTitle }: IndicatorDas
   })
   
   const getChartDescription = () => {
-    const base = selectedIndicator === "Semua Indikator"
-        ? `Menampilkan rata-rata capaian semua indikator ${category}.`
-        : `Menampilkan tren untuk: ${selectedIndicator}.`
+    const base =
+      selectedIndicator === allIndicatorsLabel
+        ? INDICATOR_TEXTS.dashboard.chartDescriptions.all(category)
+        : INDICATOR_TEXTS.dashboard.chartDescriptions.specific(selectedIndicator)
     return `${base} ${getFilterDescription(filterType, selectedDate)}`
   }
   
@@ -112,8 +118,8 @@ export function IndicatorDashboardTemplate({ category, pageTitle }: IndicatorDas
 
         <IndicatorReport
           category={category}
-          title={`Laporan ${pageTitle}`}
-          description={`Riwayat data ${pageTitle} yang telah diinput.`}
+          title={INDICATOR_TEXTS.dashboard.report.title(pageTitle)}
+          description={INDICATOR_TEXTS.dashboard.report.description(pageTitle)}
           showInputButton={true}
           chartData={chartData}
           reportDescription={getFilterDescription(filterType, selectedDate)}

--- a/src/hooks/use-indicator-data.ts
+++ b/src/hooks/use-indicator-data.ts
@@ -6,6 +6,7 @@ import { format, parseISO } from "date-fns"
 import { id as IndonesianLocale } from "date-fns/locale"
 import { Indicator } from "@/store/indicator-store"
 import { FilterType, getFilterRange } from "@/lib/indicator-utils"
+import { INDICATOR_TEXTS } from "@/lib/constants"
 
 type UseIndicatorDataProps = {
   allIndicators: Indicator[];
@@ -18,20 +19,25 @@ type UseIndicatorDataProps = {
 export function useIndicatorData({ allIndicators, selectedUnit, selectedIndicator, filterType, selectedDate }: UseIndicatorDataProps) {
   
   const indicatorsForUnit = React.useMemo(() => {
-    if (selectedUnit === "Semua Unit") return allIndicators
+    if (selectedUnit === INDICATOR_TEXTS.defaults.allUnits) return allIndicators
     return allIndicators.filter(i => i.unit === selectedUnit)
   }, [allIndicators, selectedUnit])
 
   const uniqueIndicatorNames = React.useMemo(() => {
     const names = new Set(indicatorsForUnit.map(i => i.indicator))
     return [
-      { value: "Semua Indikator", label: "Semua Indikator" },
+      {
+        value: INDICATOR_TEXTS.defaults.allIndicators,
+        label: INDICATOR_TEXTS.defaults.allIndicators,
+      },
       ...Array.from(names).map(name => ({ value: name, label: name }))
     ]
   }, [indicatorsForUnit])
 
   const selectedIndicatorData = React.useMemo(() => {
-    return indicatorsForUnit.filter(i => selectedIndicator === "Semua Indikator" || i.indicator === selectedIndicator)
+    return indicatorsForUnit.filter(
+      i => selectedIndicator === INDICATOR_TEXTS.defaults.allIndicators || i.indicator === selectedIndicator
+    )
   }, [indicatorsForUnit, selectedIndicator])
 
   const { totalIndicators, meetingStandard, notMeetingStandard } = React.useMemo(() => {
@@ -73,7 +79,10 @@ export function useIndicatorData({ allIndicators, selectedUnit, selectedIndicato
           acc[key] = {
             date: parseISO(curr.period),
             Capaian: 0,
-            Standar: selectedIndicator !== "Semua Indikator" ? curr.standard : undefined,
+            Standar:
+              selectedIndicator !== INDICATOR_TEXTS.defaults.allIndicators
+                ? curr.standard
+                : undefined,
             count: 0,
             unit: curr.standardUnit,
           }
@@ -89,14 +98,17 @@ export function useIndicatorData({ allIndicators, selectedUnit, selectedIndicato
       .map(d => {
         const capaian = parseFloat((d.Capaian / d.count).toFixed(1));
         return {
-        ...d,
-        Capaian: capaian,
-        Standar: d.Standar,
-        name: ["daily"].includes(filterType) ? format(d.date, "HH:mm")
-            : ["yearly", "3m", "6m", "1y", "3y"].includes(filterType) ? format(d.date, "MMM", { locale: IndonesianLocale })
-            : format(d.date, "dd MMM"),
-        label: `${capaian}${d.unit}`
-      }})
+          ...d,
+          Capaian: capaian,
+          Standar: d.Standar,
+          name: ["daily"].includes(filterType)
+            ? format(d.date, "HH:mm")
+            : ["yearly", "3m", "6m", "1y", "3y"].includes(filterType)
+              ? format(d.date, "MMM", { locale: IndonesianLocale })
+              : format(d.date, "dd MMM"),
+          label: `${capaian}${d.unit}`,
+        }
+      })
       .sort((a, b) => a.date.getTime() - b.date.getTime())
   }, [filteredIndicatorsForTable, filterType, selectedIndicator])
 

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -1,4 +1,114 @@
 
+export const INDICATOR_TEXTS = {
+  defaults: {
+    allUnits: "Semua Unit",
+    allIndicators: "Semua Indikator",
+  },
+  filterCard: {
+    title: "Filter & Tampilan Data",
+    description: "Gunakan filter di bawah untuk menampilkan data yang lebih spesifik.",
+    labels: {
+      filter: "Filter Data",
+      displayRange: "Tampilan & Rentang Waktu",
+      custom: "Filter Kustom",
+    },
+    placeholders: {
+      unit: "Pilih unit...",
+      unitSearch: "Cari unit...",
+      indicator: "Pilih indikator...",
+      indicatorSearch: "Cari indikator...",
+      range: "Pilih rentang...",
+      date: "Pilih tanggal",
+    },
+    filterTypeOptions: [
+      { value: "this_month", label: "Bulan Ini" },
+      { value: "7d", label: "7 Hari Terakhir" },
+      { value: "30d", label: "30 Hari Terakhir" },
+      { value: "3m", label: "3 Bulan Terakhir" },
+      { value: "6m", label: "6 Bulan Terakhir" },
+      { value: "1y", label: "1 Tahun Terakhir" },
+      { value: "daily", label: "Harian (Custom)" },
+      { value: "monthly", label: "Bulanan (Custom)" },
+      { value: "yearly", label: "Tahunan (Custom)" },
+    ],
+  },
+  chartCard: {
+    title: "Capaian Indikator Terkini",
+    emptyState: "Tidak cukup data untuk menampilkan grafik.",
+    tooltip: {
+      capaian: "Capaian",
+      standar: "Standar",
+    },
+  },
+  dashboard: {
+    chartDescriptions: {
+      all: (category: string) =>
+        `Menampilkan rata-rata capaian semua indikator ${category}.`,
+      specific: (indicator: string) =>
+        `Menampilkan tren untuk: ${indicator}.`,
+    },
+    report: {
+      title: (pageTitle: string) => `Laporan ${pageTitle}`,
+      description: (pageTitle: string) =>
+        `Riwayat data ${pageTitle} yang telah diinput.`,
+    },
+    pageTitles: {
+      "IMP-RS": "Indikator Mutu Prioritas RS (IMP-RS)",
+      IMPU: "Indikator Mutu Prioritas Unit (IMPU)",
+      SPM: "Standar Pelayanan Minimal (SPM)",
+    },
+    categoryLabels: {
+      INM: "Indikator Nasional Mutu",
+      "IMP-RS": "Indikator Mutu Prioritas RS",
+      IMPU: "Indikator Mutu Prioritas Unit",
+      SPM: "Standar Pelayanan Minimal",
+    },
+  },
+  report: {
+    defaultTitle: (category: string) => `Laporan Indikator ${category}`,
+    defaultDescription: (category: string) =>
+      `Riwayat data indikator ${category} yang telah diinput.`,
+    inputButton: "Input Data Capaian",
+    tooltip: (category: string) =>
+      `Tidak ada indikator ${category} yang diverifikasi untuk unit Anda.`,
+    emptyChart: "Tidak ada data untuk periode ini.",
+    previewTitle: (title: string | undefined, category: string) =>
+      `Laporan Capaian ${title || `Indikator ${category}`}`,
+  },
+  statCards: {
+    totalTitle: (category: string) => `Total Indikator ${category}`,
+    totalDescription: "indikator yang dimonitor",
+    meetingTitle: "Memenuhi Standar",
+    meetingDescription: "capaian bulan ini",
+    notMeetingTitle: "Tidak Memenuhi Standar",
+    notMeetingDescription: "capaian bulan ini",
+  },
+  reportTable: {
+    headers: {
+      indicator: "Indikator",
+      category: "Kategori",
+      period: "Periode",
+      ratio: "Capaian",
+      standard: "Standar",
+      status: "Status",
+      actions: "Aksi",
+    },
+    invalidDate: "Tanggal Invalid",
+    tooltip: {
+      title: "Rincian Perhitungan",
+      formulaLabel: "Formula:",
+      substitutionLabel: "Substitusi:",
+    },
+    emptyState: "Tidak ada hasil.",
+    summary: (filtered: number, total: number) =>
+      `Menampilkan ${filtered} dari ${total} total data.`,
+    pagination: {
+      previous: "Sebelumnya",
+      next: "Berikutnya",
+    },
+  },
+} as const;
+
 export const HOSPITAL_UNITS = [
     "Rawat Inap - Bougenville",
     "Rawat Inap - Anggrek",


### PR DESCRIPTION
## Summary
- add INDICATOR_TEXTS to centralize indicator dashboard labels and options
- refactor indicator dashboard components, hook, and category pages to consume the shared constants
- reuse centralized category labels inside the reports page to eliminate duplicated strings

## Testing
- npm run lint
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_b_68cccb3fe45c83248fd8d210beaa3924